### PR TITLE
fix: setup wizard polish and production fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ nul
 forge-repo/
 pywemo_repo/
 _ignore/
+New Text Document.txt

--- a/packages/bridge/package.json
+++ b/packages/bridge/package.json
@@ -7,7 +7,8 @@
   "main": "src/main.ts",
   "scripts": {
     "dev": "bun --watch src/main.ts",
-    "build": "bun build src/main.ts --compile --outfile=dist/open-wemo",
+    "build": "powershell -ExecutionPolicy Bypass -File scripts/build-windows.ps1",
+    "build:console": "bun build src/main.ts --compile --outfile=dist/open-wemo",
     "build:windows": "bun build src/main.ts --compile --target=bun-windows-x64 --outfile=dist/open-wemo-win.exe",
     "build:mac": "bun build src/main.ts --compile --target=bun-darwin-arm64 --outfile=dist/open-wemo-mac",
     "build:mac-intel": "bun build src/main.ts --compile --target=bun-darwin-x64 --outfile=dist/open-wemo-mac-intel",

--- a/packages/bridge/scripts/build-windows.ps1
+++ b/packages/bridge/scripts/build-windows.ps1
@@ -1,0 +1,89 @@
+# Build script for Windows - compiles and patches exe for GUI subsystem
+# This hides the console window when running the app
+
+param(
+    [switch]$SkipEditbin
+)
+
+$ErrorActionPreference = "Stop"
+
+Write-Host "=== Open Wemo Windows Build ===" -ForegroundColor Cyan
+
+# Get version from package.json
+$packageJson = Get-Content -Path "package.json" -Raw | ConvertFrom-Json
+$version = $packageJson.version
+Write-Host "Version: $version" -ForegroundColor White
+
+# Step 1: Compile with Bun
+Write-Host "`n[1/2] Compiling with Bun..." -ForegroundColor Yellow
+$outFile = "dist/open-wemo-$version-win"
+bun build src/main.ts --compile --outfile=$outFile
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "Build failed!" -ForegroundColor Red
+    exit 1
+}
+
+$exePath = "$outFile.exe"
+if (-not (Test-Path $exePath)) {
+    Write-Host "Error: $exePath not found after build" -ForegroundColor Red
+    exit 1
+}
+
+Write-Host "Compiled: $exePath" -ForegroundColor Green
+
+# Step 2: Patch with editbin to change subsystem from CONSOLE to WINDOWS
+if ($SkipEditbin) {
+    Write-Host "`n[2/2] Skipping editbin (console window will be visible)" -ForegroundColor Yellow
+} else {
+    Write-Host "`n[2/2] Patching subsystem with editbin..." -ForegroundColor Yellow
+    
+    # Find editbin in Visual Studio installation
+    $editbinPaths = @(
+        "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\*\bin\Hostx64\x64\editbin.exe",
+        "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\*\bin\Hostx64\x64\editbin.exe",
+        "C:\Program Files\Microsoft Visual Studio\2019\*\VC\Tools\MSVC\*\bin\Hostx64\x64\editbin.exe",
+        "C:\Program Files\Microsoft Visual Studio\2022\*\VC\Tools\MSVC\*\bin\Hostx64\x64\editbin.exe"
+    )
+    
+    $editbin = $null
+    foreach ($pattern in $editbinPaths) {
+        $found = Get-ChildItem -Path $pattern -ErrorAction SilentlyContinue | Select-Object -First 1
+        if ($found) {
+            $editbin = $found.FullName
+            break
+        }
+    }
+    
+    if (-not $editbin) {
+        Write-Host "Warning: editbin.exe not found. Console window will be visible." -ForegroundColor Yellow
+        Write-Host "Install Visual Studio Build Tools for GUI mode." -ForegroundColor Yellow
+    } else {
+        Write-Host "Using: $editbin" -ForegroundColor Gray
+        
+        # editbin requires vcvars to be set up for DLL paths
+        $vcvarsPath = Split-Path (Split-Path (Split-Path (Split-Path (Split-Path $editbin))))
+        $vcvarsPath = Join-Path $vcvarsPath "..\..\..\..\Auxiliary\Build\vcvars64.bat"
+        $vcvarsPath = (Resolve-Path $vcvarsPath -ErrorAction SilentlyContinue).Path
+        
+        if ($vcvarsPath -and (Test-Path $vcvarsPath)) {
+            # Run editbin in a cmd shell with vcvars
+            $cmd = "call `"$vcvarsPath`" >nul 2>&1 && `"$editbin`" /SUBSYSTEM:WINDOWS `"$exePath`""
+            cmd /c $cmd
+        } else {
+            # Try running editbin directly
+            & $editbin /SUBSYSTEM:WINDOWS $exePath
+        }
+        
+        if ($LASTEXITCODE -eq 0) {
+            Write-Host "Patched to GUI subsystem (no console window)" -ForegroundColor Green
+        } else {
+            Write-Host "Warning: editbin failed. Console window will be visible." -ForegroundColor Yellow
+        }
+    }
+}
+
+# Show result
+$size = (Get-Item $exePath).Length / 1MB
+Write-Host "`n=== Build Complete ===" -ForegroundColor Cyan
+Write-Host "Output: $exePath" -ForegroundColor White
+Write-Host "Size: $([math]::Round($size, 2)) MB" -ForegroundColor White

--- a/packages/bridge/src/server/index.ts
+++ b/packages/bridge/src/server/index.ts
@@ -22,7 +22,7 @@ import { toApiError } from "./errors";
 import { deviceRoutes } from "./routes/devices";
 import { discoveryRoutes } from "./routes/discovery";
 import { setupRoutes } from "./routes/setup";
-import { initStaticFiles, staticFileMiddleware } from "./static";
+import { initStaticFiles, isDevMode, staticFileMiddleware } from "./static";
 
 /**
  * Generates a debug page to preview install instructions modals.
@@ -323,7 +323,8 @@ export function createApp(config: ServerConfig = {}): Hono {
   });
 
   // Device setup page (for configuring new Wemo devices' WiFi)
-  app.get("/setup", createSetupRoute(DEFAULT_CONFIG.port));
+  // Debug mode shows diagnostics panel (only in dev)
+  app.get("/setup", createSetupRoute(DEFAULT_CONFIG.port, isDevMode()));
 
   // API endpoint to save welcome preferences
   app.post("/api/welcome/complete", async (c) => {

--- a/packages/bridge/src/server/static.ts
+++ b/packages/bridge/src/server/static.ts
@@ -22,6 +22,7 @@ import iconSvgPath from "../../../web/icons/icon.svg" with { type: "file" };
 import indexHtmlPath from "../../../web/index.html" with { type: "file" };
 import apiJsPath from "../../../web/js/api.js" with { type: "file" };
 import appJsPath from "../../../web/js/app.js" with { type: "file" };
+import setupModeJsPath from "../../../web/js/setup-mode.js" with { type: "file" };
 import manifestJsonPath from "../../../web/manifest.json" with { type: "file" };
 import swJsPath from "../../../web/sw.js" with { type: "file" };
 
@@ -33,6 +34,7 @@ const EMBEDDED_FILES: Record<string, string> = {
   "/css/style.css": String(styleCssPath),
   "/js/app.js": String(appJsPath),
   "/js/api.js": String(apiJsPath),
+  "/js/setup-mode.js": String(setupModeJsPath),
   "/sw.js": String(swJsPath),
   "/manifest.json": String(manifestJsonPath),
   "/icons/icon.svg": String(iconSvgPath),
@@ -74,8 +76,15 @@ const fileCache = new Map<string, { content: Uint8Array; mimeType: string }>();
  * Detects if we're running as a compiled binary.
  * Compiled binaries have import.meta.dir containing "~BUN" or starting with "$bunfs"
  */
-function isCompiledBinary(): boolean {
+export function isCompiledBinary(): boolean {
   return import.meta.dir.includes("~BUN") || import.meta.dir.startsWith("$bunfs");
+}
+
+/**
+ * Detects if we're running in development mode.
+ */
+export function isDevMode(): boolean {
+  return !isCompiledBinary();
 }
 
 /**


### PR DESCRIPTION
## Summary

Follow-up fixes after the initial WiFi device setup wizard merge.

### Changes

- **Windows build script**: Added PowerShell script with editbin to patch GUI subsystem (hides console window)
- **CLI flag**: Added `--reset-db` to delete database and start fresh
- **Embedded files**: Added missing `setup-mode.js` to compiled binary
- **Production fixes**: Guard all diagnostic panel references with null checks
- **UX improvements**: 
  - Removed manual SSID entry (dropdown only with refresh button)
  - Redirect to device list after successful setup
  - Hide diagnostics panel in production builds

### Testing

```bash
# Build Windows binary
cd packages/bridge && bun run build

# Reset database
open-wemo --reset-db
```