### PR TITLE
feat(matter): add local Matter bridge for Google Home

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Open Wemo consists of two parts that work together:
 | **Automatic Discovery** | Finds all WeMo devices on your network with one click |
 | **Built-in Device Setup** | Configure new WeMo devices' WiFi — no Belkin app needed |
 | **Simple Toggle Control** | Tap to turn devices on or off — instant feedback |
+| **Google Home (Matter)** | Expose switches/plugs to Google Home, Apple Home, or Alexa locally — Settings → Google Home & Matter; setup: [docs/GOOGLE-HOME.md](docs/GOOGLE-HOME.md); how it works: [docs/MATTER.md](docs/MATTER.md) |
 | **Power Monitoring** | See real-time watts and daily kWh for Insight devices |
 | **Works Offline** | App shows last-known states when bridge is unreachable |
 | **Dark & Light Themes** | Choose your preferred appearance, or follow system |

--- a/bun.lock
+++ b/bun.lock
@@ -12,8 +12,10 @@
     },
     "packages/bridge": {
       "name": "@open-wemo/bridge",
-      "version": "0.2.1",
+      "version": "0.4.1",
       "dependencies": {
+        "@matter/main": "^0.17.7",
+        "@matter/nodejs": "^0.17.7",
         "fast-xml-parser": "^5.3.3",
         "fflate": "^0.8.2",
         "hono": "^4.11.4",
@@ -30,7 +32,7 @@
     },
     "packages/web": {
       "name": "@open-wemo/web",
-      "version": "0.2.0",
+      "version": "0.4.1",
     },
   },
   "packages": {
@@ -51,6 +53,24 @@
     "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@1.9.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg=="],
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@1.9.4", "", { "os": "win32", "cpu": "x64" }, "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA=="],
+
+    "@matter/general": ["@matter/general@0.17.7", "", { "dependencies": { "@noble/curves": "^2.2.0" } }, "sha512-1k1px59FraPyge6wuK+1Wf/RyK/FpKoyOL6F8JpNRaMKh0CsIBkqcj6R46no2vkcqe7yzUBIo50x9dKklDJzJQ=="],
+
+    "@matter/main": ["@matter/main@0.17.7", "", { "dependencies": { "@matter/general": "0.17.7", "@matter/model": "0.17.7", "@matter/node": "0.17.7", "@matter/protocol": "0.17.7", "@matter/types": "0.17.7" }, "optionalDependencies": { "@matter/nodejs": "0.17.7" } }, "sha512-3D/n9Q6JiqWdkPI49CRDY76GUHJ1GqlKIZ1YEeQp93khf+MAtzS9ttT98ifuVQUMpK/l5i/xcJRWJtHU28fKBw=="],
+
+    "@matter/model": ["@matter/model@0.17.7", "", { "dependencies": { "@matter/general": "0.17.7" } }, "sha512-e8L/JVt3pG97aYZ/JU5R3dRSv664qR7/3y+B0ySXRbbdOwirL7u4CCPRURDFG+u2yvsGSIh+18uABj6yIcP3CA=="],
+
+    "@matter/node": ["@matter/node@0.17.7", "", { "dependencies": { "@matter/general": "0.17.7", "@matter/model": "0.17.7", "@matter/protocol": "0.17.7", "@matter/types": "0.17.7" } }, "sha512-vqAorFQPQ7aa5Qhpu7iRUALKwuDUazuAiotyUyhjpR7GF6zFCZ90xJwfCWKYhTsTao6Ylr2nGFtEPsbjBXpqzQ=="],
+
+    "@matter/nodejs": ["@matter/nodejs@0.17.7", "", { "dependencies": { "@matter/general": "0.17.7", "@matter/node": "0.17.7", "@matter/protocol": "0.17.7", "@matter/types": "0.17.7" } }, "sha512-9ZByr+p/Bf3ezip6IZ/4DdMLUo3xDdBO82IbTmqsga4aym5NyCdDH6FSGZfWi+sN85+ZmQdxGTJ8h5kr1FKLhQ=="],
+
+    "@matter/protocol": ["@matter/protocol@0.17.7", "", { "dependencies": { "@matter/general": "0.17.7", "@matter/model": "0.17.7", "@matter/types": "0.17.7" } }, "sha512-q9e96VBrrMJFS0PYlTAW2YD7qVzhnqI3U/AvqFAhgd/Czo60DuAsPjttmI+VYijuK1oyho1Bi7BCJGgMjbtPhg=="],
+
+    "@matter/types": ["@matter/types@0.17.7", "", { "dependencies": { "@matter/general": "0.17.7", "@matter/model": "0.17.7" } }, "sha512-NSFAlSyMUkCuYSzwtlOGb1gkmH8uFaZwpTelZY6EdTjhVMDu+meOE/CEHVzQmcAK+x8Mv2hjKlv1qCzUOqj7zQ=="],
+
+    "@noble/curves": ["@noble/curves@2.2.0", "", { "dependencies": { "@noble/hashes": "2.2.0" } }, "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ=="],
+
+    "@noble/hashes": ["@noble/hashes@2.2.0", "", {}, "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg=="],
 
     "@open-wemo/bridge": ["@open-wemo/bridge@workspace:packages/bridge"],
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -953,4 +953,100 @@ const result = await fetch(`${API}/devices/${deviceId}/keepalive`, {
 // Get diagnostics
 const diagnostics = await fetch(`${API}/devices/${deviceId}/insight/diagnostics`)
   .then(r => r.json());
+
+// Matter / Google Home status
+const matter = await fetch(`${API}/integrations/matter/status`).then(r => r.json());
+
+// Enable Matter bridge
+await fetch(`${API}/integrations/matter/enable`, { method: 'POST' });
 ```
+
+## Matter Integration
+
+See [GOOGLE-HOME.md](./GOOGLE-HOME.md) for user setup. API base path: `/api/integrations/matter`.
+
+### Get Status
+
+```http
+GET /api/integrations/matter/status
+```
+
+**Response:**
+```json
+{
+  "enabled": true,
+  "running": true,
+  "commissioned": false,
+  "deviceCount": 3,
+  "skippedCount": 0,
+  "identity": {
+    "vendorId": 65521,
+    "productId": 32769,
+    "vendorIdHex": "0xFFF1",
+    "productIdHex": "0x8001"
+  },
+  "port": 5540,
+  "storagePath": "C:\\Users\\me\\AppData\\Roaming\\open-wemo\\matter",
+  "pairing": {
+    "qrPairingCode": "MT:...",
+    "manualPairingCode": "34970112332",
+    "passcode": 20202021,
+    "discriminator": 3840,
+    "commissioned": false
+  }
+}
+```
+
+### Enable / Disable
+
+```http
+POST /api/integrations/matter/enable
+POST /api/integrations/matter/disable
+```
+
+### Reset Pairing
+
+```http
+POST /api/integrations/matter/reset
+```
+
+Erases commissioned fabrics so the bridge can be paired again. Uses the Matter factory-reset flow while running, so the QR code and setup code stay the same.
+
+### Set Vendor / Product ID
+
+```http
+PUT /api/integrations/matter/identity
+Content-Type: application/json
+
+{
+  "vendorId": "0xFFF1",
+  "productId": "0x8001"
+}
+```
+
+Both fields accept a hex string or a decimal number. The IDs must match the Matter integration registered in the Google Home Developer Console. Changing them clears the existing pairing and changes the QR payload. Returns `400` for values that are not integers in range.
+
+### Set Device Matter Kind
+
+```http
+PUT /api/integrations/matter/devices/:id/kind
+Content-Type: application/json
+
+{
+  "kind": "plug"
+}
+```
+
+`kind` is `"plug"`, `"light"`, `"skip"`, or `null` (clear override and use automatic mapping). Recreates the Matter endpoint when the bridge is running. Controllers may need remove + re-pair to pick up a new type.
+
+`GET /status` includes a `devices` array: `{ id, name, wemoType, matterKind, autoKind, source, exposed }`.
+
+### Pairing Codes
+
+```http
+GET /api/integrations/matter/pairing
+```
+
+Returns `503` if Matter is not enabled or not running.
+
+Commissioning UI pages: `GET /matter` (standalone) or the **Google Home & Matter** panel in Settings on the PWA.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -76,9 +76,24 @@ bridge/
 │   │   ├── static.ts        # Static file serving
 │   │   ├── errors.ts        # Error handling
 │   │   └── routes/
-│   │       ├── devices.ts   # Device CRUD + control
+│   │       ├── devices.ts   # Device CRUD + control (via DeviceService)
 │   │       ├── discovery.ts # Network scanning
-│   │       └── timers.ts    # Timer CRUD API endpoints
+│   │       ├── timers.ts    # Timer CRUD API endpoints
+│   │       └── matter.ts    # Matter enable/status/pairing API
+│   │
+│   ├── device-service/      # Shared device boundary for API + integrations
+│   │   ├── index.ts         # DeviceService singleton + lifecycle events
+│   │   ├── types.ts
+│   │   └── events.ts
+│   │
+│   ├── integrations/        # Smart-home integrations
+│   │   ├── index.ts         # IntegrationManager
+│   │   └── matter/          # Matter bridge (Google Home / Apple / Alexa)
+│   │       ├── bridge.ts
+│   │       ├── mapper.ts
+│   │       ├── kinds.ts     # Optional per-device kind overrides
+│   │       ├── storage.ts
+│   │       └── commissioning.ts
 │   │
 │   ├── wemo/                # WeMo protocol implementation
 │   │   ├── types.ts         # Type definitions
@@ -102,6 +117,22 @@ bridge/
 │
 └── assets/                  # Icons and resources
 ```
+
+### Matter / Google Home
+
+When `matter_enabled` is set, the bridge starts an in-process Matter aggregator (via `@matter/main` + `@matter/nodejs`) that exposes saved WeMo on/off devices to controllers such as Google Home. See [GOOGLE-HOME.md](./GOOGLE-HOME.md).
+
+```
+WeMo API (SOAP)
+      ↓
+DeviceService  ←→  REST / PWA
+      ↓
+Matter Bridge  ←→  Google Home (LAN)
+```
+
+Matter persistence uses matter.js's SQLite storage driver rather than the default file driver. The file driver saves each key by writing `<key>.tmp` and renaming it over the live file, which intermittently fails with `EPERM` under Bun on Windows — that aborts commissioning and crashes the Matter environment so it cannot restart in-process. matter.js migrates existing file-based storage on first start.
+
+Resetting pairing calls `ServerNode.erase()` while the node is running, because the node holds its own storage handles; deleting the files from outside fails with `EBUSY` on Windows. The file-deletion path in `matter/storage.ts` is only a fallback for when the bridge is stopped, and defers anything still locked to the next start.
 
 ### `packages/web/` - PWA Frontend
 
@@ -217,9 +248,10 @@ web/
 
 ### Local Network Only
 
-- Bridge binds to local IP, not 0.0.0.0
-- No cloud connectivity required
-- No external API exposure
+- HTTP API binds for LAN access (port 51515)
+- Matter bridge advertises on the LAN (UDP 5540 + mDNS) when enabled
+- No cloud connectivity required for WeMo control or Google Home (Matter)
+- No external API exposure beyond the local network
 
 ### No Authentication (by design)
 

--- a/docs/GOOGLE-HOME.md
+++ b/docs/GOOGLE-HOME.md
@@ -1,0 +1,128 @@
+# Google Home (Matter Bridge)
+
+Open Wemo can expose your WeMo switches and plugs to **Google Home** by running a local **Matter bridge**. Control stays on your LAN — no Belkin cloud is required.
+
+The same Matter bridge also works with **Apple Home** and **Amazon Alexa**.
+
+> **Read this first if you use Google Home.** Google refuses to commission *uncertified* Matter devices unless the device's Vendor ID / Product ID pair is registered as a Matter integration in the [Google Home Developer Console](https://console.home.google.com/projects). This is a one-time, free setup — see [Register with Google](#register-with-google-required-once) below. Apple Home and Alexa do not require it.
+
+## Requirements
+
+- Open Wemo Bridge running on a computer on the same Wi‑Fi as your phone and WeMo devices
+- Google Home app (Android or iOS)
+- A **Nest Matter hub** on the same Wi‑Fi (Nest Mini, Nest Audio, Nest Hub, Nest Wifi Pro, Google TV Streamer, etc.) — required for Matter control in Google Home
+- WeMo devices already discovered and saved in Open Wemo
+- A Google Home Developer Console project (Google Home only — see below)
+
+## Setup
+
+1. Start Open Wemo on your computer.
+2. Turn on the bridge in either place:
+   - **PWA:** open `http://localhost:51515`, tap the gear icon → **Google Home & Matter**, then flip the switch.
+   - **Tray menu:** **Link to Google Home**, or check **Matter Bridge**. The standalone page lives at `http://localhost:51515/matter`.
+3. Complete the [Google registration](#register-with-google-required-once) with the Vendor ID and Product ID shown in that panel.
+4. In the Google Home app:
+   - Tap **Devices** → **Add** → **Matter-enabled device**
+   - Scan the QR code shown in Open Wemo (or enter the setup code)
+5. Assign rooms to your devices in Google Home.
+
+**Where is the on/off toggle?** Google Home’s **device settings** page (Name / Room / Linked Matter / Remove) never shows controls. Use the **home or room tile**: tap to toggle, or touch-and-hold for the control sheet. Voice (“Hey Google, turn on Salt lamp”) also works once a Nest hub is online.
+
+Keep the Open Wemo Bridge running whenever you want voice or Google Home control. If the bridge is offline, Matter devices become unreachable until it starts again.
+
+For how the bridge maps WeMo types to Matter plugs/lights, see [MATTER.md](./MATTER.md).
+
+## Register with Google (required once)
+
+Google Home only commissions test/uncertified Matter devices when a matching integration exists in the Developer Console and you commission with an account tied to that project. Without it, the Google Home app discovers Open Wemo, then fails with **"Couldn't find device"** or **"Something went wrong"**.
+
+1. Go to the [Google Home Developer Console](https://console.home.google.com/projects) and sign in with the same Google account your Google Home uses.
+2. **Create a project**, then **Add integration** → **Matter**.
+3. In Setup, enter the IDs shown in Open Wemo's Matter panel:
+   - Vendor ID: `0xFFF1` (a CSA test VID)
+   - Product ID: `0x8001`
+4. Save the integration. Every VID/PID pair can only be used by one integration, so pick a different Product ID in both places if that pair is already taken.
+5. Commission from the Google Home app signed in as a project member (or a Field Trial user you added).
+
+If you need different IDs, change them in **Google Home & Matter → Advanced → Vendor ID / Product ID**. Saving restarts the bridge and clears the existing pairing, since the identity is baked into commissioned fabrics.
+
+## What is supported
+
+| WeMo type | Google Home / Matter |
+|-----------|----------------------|
+| Switch, Mini, Insight | On/Off plug |
+| LightSwitch, Bulb, Dimmer | On/Off light (brightness later) |
+| Unknown | On/Off plug (default; override in Settings if needed) |
+| Motion | Not exposed |
+
+Insight power monitoring is not exposed to Matter yet. Types are chosen automatically; see [MATTER.md](./MATTER.md).
+
+## How it works
+
+```
+Google Home / Nest
+        │  Matter (local Wi‑Fi)
+        ▼
+Open Wemo Matter Bridge  (UDP port 5540 + mDNS)
+        │
+        ▼
+DeviceService → WeMo SOAP (existing protocol)
+```
+
+- Pairing credentials and fabric data are stored under your app data directory in a `matter/` folder (for example `%APPDATA%\open-wemo\matter` on Windows).
+- Enabling Matter sets the SQLite setting `matter_enabled=true` so the bridge auto-starts next launch.
+
+## API
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/integrations/matter/status` | Enabled/running/commissioned, device count, identity, port |
+| POST | `/api/integrations/matter/enable` | Enable and start the Matter bridge |
+| POST | `/api/integrations/matter/disable` | Stop and disable the Matter bridge |
+| POST | `/api/integrations/matter/reset` | Clear commissioned fabrics so the bridge can pair again |
+| PUT | `/api/integrations/matter/identity` | Set vendor/product IDs (`{"vendorId":"0xFFF1","productId":"0x8001"}`) |
+| PUT | `/api/integrations/matter/devices/:id/kind` | Override Matter kind (`plug` / `light` / `skip` / `null`) |
+| GET | `/api/integrations/matter/pairing` | QR / manual pairing codes |
+
+## Troubleshooting
+
+**Google Home finds something, then says "Couldn't find device"**
+The VID/PID is not registered in the Google Home Developer Console, or you are commissioning with an account that is not a member of that project. See [Register with Google](#register-with-google-required-once).
+
+**Android shows "Something went wrong" partway through**
+A long-standing Google bug omits the mandatory Matter country code on some Android builds. Commission once from the Google Home app on an iPhone; afterwards the devices work normally from Android and Nest speakers.
+
+**Nothing is discovered at all**
+Phone and computer must be on the same subnet with mDNS allowed. Guest networks, "client isolation"/AP isolation (common on apartment and campus Wi‑Fi), VPNs, and separate 2.4/5 GHz SSIDs all block commissioning. Also allow `bun.exe` (dev) or `open-wemo.exe` through the firewall for the active network profile:
+
+```powershell
+New-NetFirewallRule -DisplayName "Open Wemo Matter" -Direction Inbound -Protocol UDP -LocalPort 5540 -Action Allow
+Get-NetConnectionProfile   # confirm the profile your Wi-Fi uses is covered
+```
+
+**"Already linked" / can't re-pair**
+Remove "Open Wemo" from Google Home, then use **Advanced → Reset pairing** in the Matter panel (or `POST /api/integrations/matter/reset`) and scan the QR again.
+
+**Devices don't appear after a successful pairing**
+Confirm Open Wemo lists the devices and the Matter panel reports them as exposed. Motion sensors are intentionally skipped.
+
+**Device appears but has no on/off control**
+1. Open the **home/room tile**, not the settings page (settings never has a toggle).
+2. Confirm a Nest Matter hub is on the same network and online.
+3. In Open Wemo → Google Home & Matter, check the device is listed as **Plug** or **Light** (not Skipped). Unknown WeMo types default to Plug; you can override under Advanced if needed.
+4. If you changed the Matter type after pairing, remove the device from Google Home and pair again.
+
+**Commands fail**
+The WeMo device may be offline. Check it in the Open Wemo PWA. Matter marks the endpoint unreachable when SOAP fails.
+
+**Port conflict**
+The Matter bridge listens on UDP **5540**. Ensure nothing else binds that port.
+
+## Development
+
+Phase 0 compatibility spike (Bun + `@matter/nodejs`):
+
+```bash
+cd packages/bridge
+bun scripts/matter-spike.ts
+```

--- a/docs/MATTER.md
+++ b/docs/MATTER.md
@@ -1,0 +1,106 @@
+# Matter Bridge Component
+
+This document describes how Open Wemo’s Matter integration works. For user setup (Google Home commissioning, Developer Console, troubleshooting), see [GOOGLE-HOME.md](./GOOGLE-HOME.md). For HTTP endpoints, see [API.md](./API.md).
+
+## Purpose
+
+Open Wemo runs an in-process **Matter aggregator bridge** that exposes saved WeMo on/off devices to controllers such as:
+
+- Google Home
+- Apple Home
+- Amazon Alexa
+
+Control stays on the LAN. There is no Belkin cloud and no Google Smart Home Action cloud fulfillment for device control.
+
+## Architecture
+
+```
+WeMo devices (SOAP / UPnP)
+        ▲
+        │
+ DeviceService  ←→  REST API / PWA
+        │
+        │ events (deviceAdded, stateChanged, …)
+        ▼
+ MatterBridge (ServerNode + AggregatorEndpoint)
+        │
+        │ Matter over IP (UDP 5540 + mDNS)
+        ▼
+ Google Home / Apple Home / Alexa
+```
+
+| Piece | Role |
+|-------|------|
+| `DeviceService` | Single boundary for discovery, persistence, and on/off control |
+| `IntegrationManager` | Starts/stops Matter from the `matter_enabled` setting |
+| `MatterBridge` | Owns the Matter `ServerNode`, aggregator, and bridged endpoints |
+| PWA Settings → Google Home & Matter | Enable, QR pairing, identity, per-device kind overrides |
+
+### Key files
+
+```
+packages/bridge/src/
+├── device-service/          # Shared device API for REST + Matter
+├── integrations/
+│   ├── index.ts             # IntegrationManager
+│   └── matter/
+│       ├── bridge.ts        # ServerNode lifecycle + sync
+│       ├── mapper.ts        # WeMo type → Matter kind
+│       ├── kinds.ts         # Optional per-device kind overrides
+│       ├── storage.ts       # Credentials + storage paths
+│       └── commissioning.ts # QR / standalone /matter page HTML
+└── server/routes/matter.ts  # REST API
+```
+
+## Device type mapping
+
+Matter device type IDs determine which controls Google Home (and other controllers) show. Open Wemo maps WeMo types automatically:
+
+| WeMo type | Matter kind | Matter device | Controller UI |
+|-----------|-------------|---------------|---------------|
+| Switch, Mini, Insight | `plug` | On/Off Plug-in Unit (`0x010A`) | Outlet / switch with on/off |
+| LightSwitch, Bulb, Dimmer | `light` | On/Off Light (`0x0100`) | Light with on/off |
+| Unknown | `plug` (default) | On/Off Plug-in Unit | On/off rather than dropping the device |
+| Motion | `skip` | — | Not exposed |
+
+**Never** use Matter’s On/Off Light Switch (`0x0103`) for WeMo actuators. In Google Home that type is a *controller* (binding), not an on/off device—so the app shows the device with **no controls**.
+
+### Override resolution
+
+1. Per-device user override (if set in Settings → Advanced, or when type is Unknown)
+2. Else automatic map from `device.deviceType`
+3. Unknown without override → `plug`
+
+Overrides are stored in SQLite settings as JSON (`matter_device_kinds`). Changing a kind recreates the Matter endpoint (device type is fixed at endpoint creation). Controllers may need remove + re-pair (or hub resync) to pick up the new type.
+
+## Lifecycle
+
+1. **Enable** — `matter_enabled=true`; `MatterBridge.start()` creates `ServerNode`, aggregator, and one bridged endpoint per exposable device.
+2. **Commission** — Controllers scan the QR / enter the setup code. Identity uses stored passcode, discriminator, vendor ID, and product ID.
+3. **Control (controller → WeMo)** — Matter `onOff` changes call `DeviceService.setOn` / `setOff` with source `"matter"`.
+4. **Control (PWA/API → controller)** — `stateChanged` events update the Matter endpoint (feedback loop ignored for `"matter"` source).
+5. **Reset** — Running bridge uses `ServerNode.erase()`; offline path clears fabric storage and may defer locked files on Windows.
+6. **Identity change** — Updates VID/PID, factory-resets fabrics, restarts if enabled.
+
+## Storage
+
+| Path | Contents |
+|------|----------|
+| `%APPDATA%/open-wemo/matter/` (Windows) | Matter root (`path.root`) |
+| `credentials.json` | Passcode, discriminator, uniqueId, vendorId, productId |
+| `open-wemo/storage.db` | matter.js SQLite fabric / node state |
+
+The default matter.js **file** storage driver is not used: under Bun on Windows, write-tmp + rename intermittently fails with `EPERM`, which crashes the Matter environment so it cannot restart in-process. SQLite is selected via `StorageService.configuredDriver`.
+
+## Google Home specifics
+
+- Uncertified VID/PID pairs must be registered in the [Google Home Developer Console](https://console.home.google.com/projects). See [GOOGLE-HOME.md](./GOOGLE-HOME.md).
+- A **Nest Matter hub** (Nest Mini, Nest Audio, Nest Hub, etc. on the same Wi‑Fi) is required for Matter control in the Google ecosystem.
+- The Google Home **device settings** page (Name / Room / Remove) never shows an on/off toggle. Controls are on the **home/room tile** (tap or touch-and-hold).
+- After changing a device’s Matter kind, remove the device from Google Home and re-pair if the tile still has no controls.
+
+## Related docs
+
+- [GOOGLE-HOME.md](./GOOGLE-HOME.md) — User setup and troubleshooting
+- [API.md](./API.md) — `/api/integrations/matter/*`
+- [ARCHITECTURE.md](./ARCHITECTURE.md) — Bridge module layout

--- a/packages/bridge/package.json
+++ b/packages/bridge/package.json
@@ -18,6 +18,8 @@
     "test": "bun test"
   },
   "dependencies": {
+    "@matter/main": "^0.17.7",
+    "@matter/nodejs": "^0.17.7",
     "fast-xml-parser": "^5.3.3",
     "fflate": "^0.8.2",
     "hono": "^4.11.4",

--- a/packages/bridge/scripts/matter-restart-test.ts
+++ b/packages/bridge/scripts/matter-restart-test.ts
@@ -1,0 +1,99 @@
+/**
+ * Reproduction: start → stop → start a Matter ServerNode twice in one process.
+ *
+ * The bridge restarts the Matter node when the user resets pairing or changes
+ * the vendor/product ID, so this must work without recreating the process.
+ *
+ * Usage: bun scripts/matter-restart-test.ts [--shared-env]
+ */
+
+import "@matter/nodejs";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Endpoint, Environment, ServerNode, StorageService, VendorId } from "@matter/main";
+import { OnOffPlugInUnitDevice } from "@matter/main/devices/on-off-plug-in-unit";
+import { AggregatorEndpoint } from "@matter/main/endpoints/aggregator";
+
+const useSharedEnv = process.argv.includes("--shared-env");
+const driverArg = process.argv.find((a) => a.startsWith("--driver="));
+const driver = driverArg?.split("=")[1];
+const storageDir = mkdtempSync(join(tmpdir(), "open-wemo-matter-restart-"));
+const PORT = 5541;
+
+async function startNode(attempt: number): Promise<ServerNode> {
+  const environment = useSharedEnv
+    ? Environment.default
+    : new Environment(`open-wemo-${attempt}`, Environment.default);
+  environment.vars.set("path.root", storageDir);
+
+  if (driver) {
+    const storage = environment.get(StorageService);
+    storage.configuredDriver = driver;
+    storage.configuredBlobDriver = driver;
+  }
+
+  const server = await ServerNode.create({
+    environment,
+    id: "open-wemo",
+    network: { port: PORT },
+    commissioning: { passcode: 20202021, discriminator: 3840 },
+    productDescription: { name: "Open Wemo", deviceType: AggregatorEndpoint.deviceType },
+    basicInformation: {
+      vendorName: "Open Wemo",
+      vendorId: VendorId(0xfff1),
+      nodeLabel: "Open Wemo",
+      productName: "Open Wemo Bridge",
+      productLabel: "WeMo Matter Bridge",
+      productId: 0x8001,
+      serialNumber: "restart-test",
+      uniqueId: "restarttest001",
+    },
+  });
+
+  const aggregator = new Endpoint(AggregatorEndpoint, { id: "aggregator" });
+  await server.add(aggregator);
+
+  const plug = new Endpoint(OnOffPlugInUnitDevice, { id: "plug1", onOff: { onOff: false } });
+  await aggregator.add(plug);
+
+  await server.start();
+  return server;
+}
+
+async function main(): Promise<void> {
+  console.log(
+    `[Restart] env mode: ${useSharedEnv ? "shared Environment.default" : "child env"}, driver: ${driver ?? "default"}`
+  );
+
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    console.log(`[Restart] --- attempt ${attempt} ---`);
+    const server = await startNode(attempt);
+    console.log(`[Restart] online=${server.lifecycle.isOnline}`);
+    console.log(`[Restart] qr=${server.state.commissioning.pairingCodes.qrPairingCode}`);
+    await new Promise((r) => setTimeout(r, 500));
+    await server.close();
+    console.log(`[Restart] closed ${attempt}`);
+    await new Promise((r) => setTimeout(r, 500));
+  }
+
+  console.log("[Restart] SUCCESS — node restarts cleanly in-process");
+}
+
+main()
+  .then(() => {
+    rmSync(storageDir, { recursive: true, force: true });
+    process.exit(0);
+  })
+  .catch((error) => {
+    console.error("[Restart] FAILED:", error);
+    if (error?.cause) {
+      console.error("[Restart] cause:", error.cause);
+    }
+    try {
+      rmSync(storageDir, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+    process.exit(1);
+  });

--- a/packages/bridge/scripts/matter-spike.ts
+++ b/packages/bridge/scripts/matter-spike.ts
@@ -1,0 +1,88 @@
+/**
+ * Phase 0 spike: verify Matter bridge can start under Bun.
+ * Run: bun scripts/matter-spike.ts
+ * Decision: in-process Bun + @matter/nodejs is viable (see SUCCESS log).
+ */
+
+import "@matter/nodejs";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Endpoint, Environment, ServerNode, VendorId } from "@matter/main";
+import { BridgedDeviceBasicInformationServer } from "@matter/main/behaviors/bridged-device-basic-information";
+import { OnOffPlugInUnitDevice } from "@matter/main/devices/on-off-plug-in-unit";
+import { AggregatorEndpoint } from "@matter/main/endpoints/aggregator";
+
+const storageDir = mkdtempSync(join(tmpdir(), "open-wemo-matter-spike-"));
+
+async function main(): Promise<void> {
+  console.log("[Spike] Storage:", storageDir);
+
+  const env = Environment.default;
+  env.vars.set("path.root", storageDir);
+
+  const server = await ServerNode.create({
+    id: "open-wemo-spike",
+    network: { port: 5540 },
+    commissioning: {
+      passcode: 20202021,
+      discriminator: 3840,
+    },
+    productDescription: {
+      name: "Open Wemo Spike",
+      deviceType: AggregatorEndpoint.deviceType,
+    },
+    basicInformation: {
+      vendorName: "Open Wemo",
+      vendorId: VendorId(0xfff1),
+      nodeLabel: "Open Wemo Spike",
+      productName: "Open Wemo Spike",
+      productLabel: "Open Wemo Bridge",
+      productId: 0x8000,
+      serialNumber: "ow-spike-001",
+      uniqueId: "open-wemo-spike-001",
+    },
+  });
+
+  const aggregator = new Endpoint(AggregatorEndpoint, { id: "aggregator" });
+  await server.add(aggregator);
+
+  const plug = new Endpoint(OnOffPlugInUnitDevice.with(BridgedDeviceBasicInformationServer), {
+    id: "test-plug",
+    bridgedDeviceBasicInformation: {
+      nodeLabel: "Spike Plug",
+      productName: "Spike Plug",
+      productLabel: "Spike Plug",
+      serialNumber: "spike-plug-1",
+      uniqueId: "spikeplug1",
+      reachable: true,
+    },
+    onOff: { onOff: false },
+  });
+  await aggregator.add(plug);
+
+  await server.start();
+
+  const pairing = server.state.commissioning.pairingCodes;
+  console.log("[Spike] Bridge started");
+  console.log("[Spike] QR:", pairing.qrPairingCode);
+  console.log("[Spike] Manual:", pairing.manualPairingCode);
+  console.log("[Spike] Commissioned:", server.lifecycle.isCommissioned);
+
+  await new Promise((r) => setTimeout(r, 2000));
+
+  await server.close();
+  console.log("[Spike] SUCCESS — Bun + matter.js in-process is viable");
+  rmSync(storageDir, { recursive: true, force: true });
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error("[Spike] FAILED:", err);
+  try {
+    rmSync(storageDir, { recursive: true, force: true });
+  } catch {
+    // ignore
+  }
+  process.exit(1);
+});

--- a/packages/bridge/src/device-service/__tests__/events.test.ts
+++ b/packages/bridge/src/device-service/__tests__/events.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import type { SavedDevice } from "../../wemo/types";
+import { WemoDeviceType } from "../../wemo/types";
+import { DeviceEventBus } from "../events";
+
+describe("DeviceEventBus", () => {
+  test("delivers typed events to subscribers", () => {
+    const bus = new DeviceEventBus();
+    const received: SavedDevice[] = [];
+
+    const unsub = bus.on("deviceAdded", (device) => {
+      received.push(device);
+    });
+
+    const device: SavedDevice = {
+      id: "d1",
+      name: "Lamp",
+      deviceType: WemoDeviceType.Switch,
+      host: "192.168.1.10",
+      port: 49153,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+
+    bus.emit("deviceAdded", device);
+    expect(received).toHaveLength(1);
+    expect(received[0]?.id).toBe("d1");
+
+    unsub();
+    bus.emit("deviceAdded", device);
+    expect(received).toHaveLength(1);
+  });
+
+  test("stateChanged carries source", () => {
+    const bus = new DeviceEventBus();
+    let source = "";
+    bus.on("stateChanged", (payload) => {
+      source = payload.source;
+    });
+    bus.emit("stateChanged", { id: "x", state: 1, isOn: true, source: "api" });
+    expect(source).toBe("api");
+  });
+});

--- a/packages/bridge/src/device-service/events.ts
+++ b/packages/bridge/src/device-service/events.ts
@@ -1,0 +1,46 @@
+/**
+ * Lightweight typed event emitter for DeviceService.
+ */
+
+import type { DeviceServiceEventMap } from "./types";
+
+type Handler<T> = (payload: T) => void;
+
+/**
+ * Minimal event bus used by DeviceService so integrations can subscribe
+ * without depending on Node's EventEmitter.
+ */
+export class DeviceEventBus {
+  private listeners = new Map<keyof DeviceServiceEventMap, Set<Handler<unknown>>>();
+
+  on<K extends keyof DeviceServiceEventMap>(
+    event: K,
+    handler: Handler<DeviceServiceEventMap[K]>
+  ): () => void {
+    let set = this.listeners.get(event);
+    if (!set) {
+      set = new Set();
+      this.listeners.set(event, set);
+    }
+    set.add(handler as Handler<unknown>);
+    return () => {
+      set?.delete(handler as Handler<unknown>);
+    };
+  }
+
+  emit<K extends keyof DeviceServiceEventMap>(event: K, payload: DeviceServiceEventMap[K]): void {
+    const set = this.listeners.get(event);
+    if (!set) return;
+    for (const handler of set) {
+      try {
+        handler(payload);
+      } catch (error) {
+        console.error(`[DeviceService] Event handler error for ${event}:`, error);
+      }
+    }
+  }
+
+  removeAllListeners(): void {
+    this.listeners.clear();
+  }
+}

--- a/packages/bridge/src/device-service/index.ts
+++ b/packages/bridge/src/device-service/index.ts
@@ -1,0 +1,499 @@
+/**
+ * DeviceService — shared boundary between REST API and smart-home integrations.
+ *
+ * Wraps SQLite persistence + WeMo SOAP control so Matter (and future
+ * integrations) do not duplicate device logic.
+ */
+
+import { getDatabase } from "../db";
+import {
+  DeviceNotFoundError,
+  DeviceOfflineError,
+  InsightNotSupportedError,
+  ValidationError,
+} from "../server/errors";
+import { WemoDeviceClient } from "../wemo/device";
+import { getDeviceByAddress } from "../wemo/discovery";
+import { InsightDeviceClient, convertToPowerData, supportsInsight } from "../wemo/insight";
+import {
+  isKeepAliveEnabled,
+  markManualOff,
+  markManualOn,
+  setKeepAliveEnabled,
+} from "../wemo/keepalive";
+import { fetchRulesDb, parseAllRulesFromDb } from "../wemo/rules";
+import { clearDeviceRules } from "../wemo/scheduler";
+import type { SavedDevice, WemoDeviceType } from "../wemo/types";
+import { DeviceEventBus } from "./events";
+import type { ControlResult, DeviceStateResult, DeviceWithState } from "./types";
+
+export type {
+  ControlResult,
+  DeviceStateResult,
+  DeviceWithState,
+  DeviceServiceEventMap,
+} from "./types";
+export { DeviceEventBus } from "./events";
+
+function withTimeout<T>(promise: Promise<T>, ms: number, fallback: T): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<T>((resolve) => setTimeout(() => resolve(fallback), ms)),
+  ]);
+}
+
+/**
+ * Central device lifecycle and control service.
+ */
+export class DeviceService {
+  readonly events = new DeviceEventBus();
+
+  /** Gets a saved device by ID, throwing if not found. */
+  requireDevice(id: string): SavedDevice {
+    const device = getDatabase().getDeviceById(id);
+    if (!device) {
+      throw new DeviceNotFoundError(id);
+    }
+    return device;
+  }
+
+  /** Lists all saved devices. */
+  listDevices(): SavedDevice[] {
+    return getDatabase().getAllDevices();
+  }
+
+  /** Lists devices with optional live state polling. */
+  async listDevicesWithState(includeState: boolean): Promise<DeviceWithState[] | SavedDevice[]> {
+    const devices = this.listDevices();
+    if (!includeState) {
+      return devices;
+    }
+    return Promise.all(
+      devices.map(async (device) => {
+        const status = await this.getState(device.id);
+        return { ...device, ...status };
+      })
+    );
+  }
+
+  /** Gets a WeMo client for a saved device, throwing if offline. */
+  async getDeviceClient(device: SavedDevice): Promise<WemoDeviceClient> {
+    const wemoDevice = await getDeviceByAddress(device.host, device.port);
+    if (!wemoDevice) {
+      throw new DeviceOfflineError(device.id, "Device not reachable");
+    }
+    return new WemoDeviceClient(wemoDevice);
+  }
+
+  /** Gets an Insight client, throwing if offline or unsupported. */
+  async getInsightClient(device: SavedDevice): Promise<InsightDeviceClient> {
+    const wemoDevice = await getDeviceByAddress(device.host, device.port);
+    if (!wemoDevice) {
+      throw new DeviceOfflineError(device.id, "Device not reachable");
+    }
+    if (!supportsInsight(wemoDevice)) {
+      throw new InsightNotSupportedError(device.id);
+    }
+    return new InsightDeviceClient(wemoDevice);
+  }
+
+  /** Polls binary state with a timeout (never throws for offline). */
+  async getState(deviceId: string): Promise<DeviceStateResult> {
+    const device = this.requireDevice(deviceId);
+    const offlineResult: DeviceStateResult = {
+      isOnline: false,
+      error: "Device not reachable (timeout)",
+    };
+
+    try {
+      return await withTimeout<DeviceStateResult>(
+        (async (): Promise<DeviceStateResult> => {
+          const client = await this.getDeviceClient(device);
+          const binaryState = await client.getBinaryState();
+          return { isOnline: true, state: binaryState };
+        })(),
+        6000,
+        offlineResult
+      );
+    } catch (error) {
+      return {
+        isOnline: false,
+        error: error instanceof Error ? error.message : "Unknown error",
+      };
+    }
+  }
+
+  /**
+   * Adds or updates a device in SQLite and emits lifecycle events.
+   */
+  async saveDevice(input: {
+    id?: string;
+    name: string;
+    host: string;
+    port?: number;
+    deviceType?: WemoDeviceType;
+  }): Promise<{ device: SavedDevice; created: boolean }> {
+    const missingFields: string[] = [];
+    if (!input.name) missingFields.push("name");
+    if (!input.host) missingFields.push("host");
+    if (missingFields.length > 0) {
+      throw new ValidationError(
+        `Missing required fields: ${missingFields.join(", ")}`,
+        missingFields
+      );
+    }
+
+    const ipv4Regex = /^(\d{1,3}\.){3}\d{1,3}$/;
+    const hostnameRegex =
+      /^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*$/;
+
+    if (!ipv4Regex.test(input.host) && !hostnameRegex.test(input.host)) {
+      throw new ValidationError("Invalid host: must be a valid IP address or hostname", ["host"]);
+    }
+
+    if (ipv4Regex.test(input.host)) {
+      const octets = input.host.split(".").map(Number);
+      if (octets.some((octet) => octet < 0 || octet > 255)) {
+        throw new ValidationError("Invalid IP address: octets must be 0-255", ["host"]);
+      }
+    }
+
+    if (input.port !== undefined) {
+      if (!Number.isInteger(input.port) || input.port < 1 || input.port > 65535) {
+        throw new ValidationError("Invalid port: must be an integer between 1 and 65535", ["port"]);
+      }
+    }
+
+    const db = getDatabase();
+    const now = new Date().toISOString();
+    let deviceId = input.id;
+    let deviceType = input.deviceType ?? ("Switch" as WemoDeviceType);
+    const existed = deviceId ? db.getDeviceById(deviceId) !== null : false;
+
+    if (!deviceId) {
+      try {
+        const discovered = await getDeviceByAddress(input.host, input.port ?? 49153);
+        if (discovered) {
+          deviceId = discovered.id;
+          deviceType = discovered.deviceType;
+        }
+      } catch {
+        // Ignore discovery errors
+      }
+    }
+
+    if (!deviceId) {
+      deviceId = `manual:${input.host}:${input.port ?? 49153}`;
+    }
+
+    const wasExisting = existed || db.getDeviceById(deviceId) !== null;
+
+    const device: SavedDevice = {
+      id: deviceId,
+      name: input.name,
+      deviceType,
+      host: input.host,
+      port: input.port ?? 49153,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    // Preserve createdAt for updates
+    if (wasExisting) {
+      const existing = db.getDeviceById(deviceId);
+      if (existing) {
+        device.createdAt = existing.createdAt;
+      }
+    }
+
+    db.saveDevice(device);
+
+    if (wasExisting) {
+      this.events.emit("deviceUpdated", device);
+    } else {
+      this.events.emit("deviceAdded", device);
+    }
+
+    return { device, created: !wasExisting };
+  }
+
+  /** Updates device properties and emits deviceUpdated. */
+  updateDevice(id: string, updates: { name?: string; host?: string; port?: number }): SavedDevice {
+    const existing = this.requireDevice(id);
+    const updated: SavedDevice = {
+      ...existing,
+      name: updates.name ?? existing.name,
+      host: updates.host ?? existing.host,
+      port: updates.port ?? existing.port,
+      updatedAt: new Date().toISOString(),
+    };
+    getDatabase().saveDevice(updated);
+    this.events.emit("deviceUpdated", updated);
+    return updated;
+  }
+
+  /**
+   * Updates host/port after background discovery (IP change).
+   * Emits deviceUpdated so Matter can refresh reachability metadata.
+   */
+  syncDeviceAddress(id: string, host: string, port: number): SavedDevice | null {
+    const existing = getDatabase().getDeviceById(id);
+    if (!existing) return null;
+    if (existing.host === host && existing.port === port) {
+      getDatabase().updateLastSeen(id);
+      return existing;
+    }
+    const updated: SavedDevice = {
+      ...existing,
+      host,
+      port,
+      updatedAt: new Date().toISOString(),
+    };
+    getDatabase().saveDevice(updated);
+    this.events.emit("deviceUpdated", updated);
+    return updated;
+  }
+
+  /** Deletes a device and emits deviceRemoved. */
+  deleteDevice(id: string): void {
+    this.requireDevice(id);
+    getDatabase().deleteDevice(id);
+    clearDeviceRules(id);
+    this.events.emit("deviceRemoved", { id });
+  }
+
+  /** Turns a device on. */
+  async setOn(deviceId: string, source: "api" | "matter" = "api"): Promise<ControlResult> {
+    const device = this.requireDevice(deviceId);
+    const client = await this.getDeviceClient(device);
+    await client.turnOn();
+    markManualOn(device.id);
+    const newState = await client.getBinaryState();
+    const result: ControlResult = {
+      id: device.id,
+      action: "on",
+      state: newState,
+      isOn: newState === 1,
+    };
+    this.events.emit("stateChanged", {
+      id: device.id,
+      state: newState,
+      isOn: result.isOn,
+      source,
+    });
+    return result;
+  }
+
+  /** Turns a device off. */
+  async setOff(deviceId: string, source: "api" | "matter" = "api"): Promise<ControlResult> {
+    const device = this.requireDevice(deviceId);
+    const client = await this.getDeviceClient(device);
+    await client.turnOff();
+    markManualOff(device.id);
+    const newState = await client.getBinaryState();
+    const result: ControlResult = {
+      id: device.id,
+      action: "off",
+      state: newState,
+      isOn: newState === 1,
+    };
+    this.events.emit("stateChanged", {
+      id: device.id,
+      state: newState,
+      isOn: result.isOn,
+      source,
+    });
+    return result;
+  }
+
+  /** Toggles a device. */
+  async toggle(deviceId: string, source: "api" | "matter" = "api"): Promise<ControlResult> {
+    const device = this.requireDevice(deviceId);
+    const client = await this.getDeviceClient(device);
+    const { binaryState } = await client.toggle();
+
+    if (binaryState === 1) {
+      markManualOn(device.id);
+    } else {
+      markManualOff(device.id);
+    }
+
+    const result: ControlResult = {
+      id: device.id,
+      action: "toggle",
+      state: binaryState,
+      isOn: binaryState === 1,
+    };
+    this.events.emit("stateChanged", {
+      id: device.id,
+      state: binaryState,
+      isOn: result.isOn,
+      source,
+    });
+    return result;
+  }
+
+  /** Gets binary state (throws if offline). */
+  async getBinaryState(deviceId: string): Promise<{
+    id: string;
+    state: number;
+    isOn: boolean;
+    isStandby: boolean;
+  }> {
+    const device = this.requireDevice(deviceId);
+    const client = await this.getDeviceClient(device);
+    const state = await client.getBinaryState();
+    return {
+      id: device.id,
+      state,
+      isOn: state === 1,
+      isStandby: state === 8,
+    };
+  }
+
+  /** Insight power data. */
+  async getInsight(deviceId: string) {
+    const device = this.requireDevice(deviceId);
+    const client = await this.getInsightClient(device);
+    const powerData = await client.getPowerData();
+    const rawParams = await client.getInsightParams();
+    return { id: device.id, power: powerData, raw: rawParams };
+  }
+
+  async getThreshold(deviceId: string) {
+    const device = this.requireDevice(deviceId);
+    const client = await this.getInsightClient(device);
+    const thresholdMilliwatts = await client.getPowerThreshold();
+    return {
+      id: device.id,
+      thresholdWatts: thresholdMilliwatts / 1000,
+      thresholdMilliwatts,
+    };
+  }
+
+  async setThreshold(deviceId: string, watts: number) {
+    if (typeof watts !== "number" || !Number.isFinite(watts) || watts < 0 || watts > 50) {
+      throw new ValidationError("Invalid watts: must be a number between 0 and 50", ["watts"]);
+    }
+    const device = this.requireDevice(deviceId);
+    const client = await this.getInsightClient(device);
+    const milliwatts = Math.round(watts * 1000);
+    await client.setPowerThreshold(milliwatts);
+    return {
+      id: device.id,
+      thresholdWatts: milliwatts / 1000,
+      thresholdMilliwatts: milliwatts,
+    };
+  }
+
+  async resetThreshold(deviceId: string) {
+    const device = this.requireDevice(deviceId);
+    const client = await this.getInsightClient(device);
+    await client.resetPowerThreshold();
+    const confirmedMilliwatts = await client.getPowerThreshold();
+    return {
+      id: device.id,
+      thresholdWatts: confirmedMilliwatts / 1000,
+      thresholdMilliwatts: confirmedMilliwatts,
+    };
+  }
+
+  getKeepAlive(deviceId: string) {
+    const device = this.requireDevice(deviceId);
+    return { id: device.id, enabled: isKeepAliveEnabled(device.id) };
+  }
+
+  async setKeepAlive(deviceId: string, enabled: boolean) {
+    if (typeof enabled !== "boolean") {
+      throw new ValidationError("Invalid enabled: must be a boolean", ["enabled"]);
+    }
+    const device = this.requireDevice(deviceId);
+    setKeepAliveEnabled(device.id, enabled);
+
+    if (device.deviceType === "Insight") {
+      try {
+        const client = await this.getInsightClient(device);
+        const autoThresholdWatts = enabled ? 0 : 8;
+        const displayThresholdMilliwatts = enabled ? 1 : 8000;
+        await Promise.all([
+          client.setAutoPowerThreshold(autoThresholdWatts),
+          client.setPowerThreshold(displayThresholdMilliwatts),
+        ]);
+
+        if (enabled) {
+          const state = await client.getBinaryState();
+          if (state === 0 || state === 8) {
+            markManualOff(device.id);
+          }
+        }
+
+        console.log(
+          `[KeepAlive] Set auto threshold to ${autoThresholdWatts}W, display threshold to ${displayThresholdMilliwatts}mW for "${device.name}"`
+        );
+      } catch (error) {
+        console.error(
+          `[KeepAlive] Failed to set power thresholds for "${device.name}":`,
+          error instanceof Error ? error.message : error
+        );
+      }
+    }
+
+    return { id: device.id, enabled };
+  }
+
+  async getInsightDiagnostics(deviceId: string) {
+    const device = this.requireDevice(deviceId);
+    const client = await this.getInsightClient(device);
+
+    const [insightParams, thresholdMilliwatts, rulesResult] = await Promise.all([
+      client.getInsightParams(),
+      client.getPowerThreshold(),
+      fetchRulesDb(device.host, device.port),
+    ]);
+
+    const powerData = convertToPowerData(insightParams);
+    const allRules = parseAllRulesFromDb(rulesResult.dbBuffer);
+    const nonTimerRules = allRules.filter((r) => r.type !== "Timer");
+    const stateLabels: Record<number, string> = { 0: "off", 1: "on", 8: "standby" };
+
+    return {
+      id: device.id,
+      insight: {
+        state: insightParams.state,
+        stateLabel: stateLabels[insightParams.state] ?? "unknown",
+        instantPowerMilliwatts: insightParams.instantPower,
+        instantPowerWatts: insightParams.instantPower / 1000,
+        reportedThresholdMilliwatts: insightParams.standbyThreshold,
+        reportedThresholdWatts: insightParams.standbyThreshold / 1000,
+        power: powerData,
+      },
+      threshold: {
+        milliwatts: thresholdMilliwatts,
+        watts: thresholdMilliwatts / 1000,
+      },
+      rules: {
+        dbVersion: rulesResult.version,
+        totalCount: allRules.length,
+        timerCount: allRules.length - nonTimerRules.length,
+        nonTimerCount: nonTimerRules.length,
+        all: allRules,
+      },
+    };
+  }
+}
+
+/** Singleton DeviceService. */
+let instance: DeviceService | null = null;
+
+export function getDeviceService(): DeviceService {
+  if (!instance) {
+    instance = new DeviceService();
+  }
+  return instance;
+}
+
+/** Reset singleton (tests). */
+export function resetDeviceService(): void {
+  instance?.events.removeAllListeners();
+  instance = null;
+}

--- a/packages/bridge/src/device-service/types.ts
+++ b/packages/bridge/src/device-service/types.ts
@@ -1,0 +1,31 @@
+/**
+ * Types for the DeviceService integration boundary.
+ */
+
+import type { SavedDevice } from "../wemo/types";
+
+/** Result of a device state poll. */
+export type DeviceStateResult = {
+  isOnline: boolean;
+  state?: number;
+  error?: string;
+};
+
+/** Result of an on/off/toggle control action. */
+export type ControlResult = {
+  id: string;
+  action: "on" | "off" | "toggle";
+  state: number;
+  isOn: boolean;
+};
+
+/** Saved device with optional live state. */
+export type DeviceWithState = SavedDevice & DeviceStateResult;
+
+/** Events emitted by DeviceService for integrations. */
+export type DeviceServiceEventMap = {
+  deviceAdded: SavedDevice;
+  deviceRemoved: { id: string };
+  deviceUpdated: SavedDevice;
+  stateChanged: { id: string; state: number; isOn: boolean; source: "api" | "matter" | "poll" };
+};

--- a/packages/bridge/src/integrations/index.ts
+++ b/packages/bridge/src/integrations/index.ts
@@ -1,0 +1,216 @@
+/**
+ * Integration manager — starts/stops smart-home integrations.
+ */
+
+import { getDatabase } from "../db";
+import { getDeviceService } from "../device-service";
+import {
+  MATTER_PORT,
+  MatterBridge,
+  type MatterBridgeStatus,
+  type MatterDeviceStatus,
+} from "./matter/bridge";
+import { getKindOverride, setKindOverride } from "./matter/kinds";
+import { type MatterDeviceKind, resolveMatterKind } from "./matter/mapper";
+import {
+  DEFAULT_PRODUCT_ID,
+  DEFAULT_VENDOR_ID,
+  getMatterStorageDir,
+  getOrCreateCredentials,
+  resetCommissioningState,
+  setMatterIdentity,
+} from "./matter/storage";
+
+export const MATTER_ENABLED_SETTING = "matter_enabled";
+
+function listDeviceStatusesOffline(): MatterDeviceStatus[] {
+  return getDeviceService()
+    .listDevices()
+    .map((device) => {
+      const override = getKindOverride(device.id);
+      const resolved = resolveMatterKind(device.deviceType, override);
+      return {
+        id: device.id,
+        name: device.name,
+        wemoType: device.deviceType,
+        matterKind: resolved.kind,
+        autoKind: resolved.autoKind,
+        source: resolved.source,
+        exposed: false,
+      };
+    });
+}
+
+/**
+ * Owns integration lifecycle for the bridge process.
+ */
+export class IntegrationManager {
+  private matter: MatterBridge | null = null;
+
+  isMatterEnabled(): boolean {
+    return getDatabase().getBoolSetting(MATTER_ENABLED_SETTING, false);
+  }
+
+  getMatterStatus(): MatterBridgeStatus {
+    if (!this.matter) {
+      const credentials = getOrCreateCredentials();
+      const devices = listDeviceStatusesOffline();
+      return {
+        running: false,
+        commissioned: false,
+        deviceCount: 0,
+        skippedCount: devices.filter((d) => d.matterKind === "skip").length,
+        devices,
+        pairing: null,
+        identity: {
+          vendorId: credentials.vendorId,
+          productId: credentials.productId,
+          vendorIdHex: `0x${credentials.vendorId.toString(16).toUpperCase().padStart(4, "0")}`,
+          productIdHex: `0x${credentials.productId.toString(16).toUpperCase().padStart(4, "0")}`,
+        },
+        port: MATTER_PORT,
+        storagePath: getMatterStorageDir(),
+      };
+    }
+    return this.matter.getStatus();
+  }
+
+  getMatterBridge(): MatterBridge | null {
+    return this.matter;
+  }
+
+  /**
+   * Starts Matter if the user setting is enabled.
+   */
+  async startFromSettings(): Promise<void> {
+    if (this.isMatterEnabled()) {
+      await this.enableMatter();
+    }
+  }
+
+  async enableMatter(): Promise<MatterBridgeStatus> {
+    getDatabase().setBoolSetting(MATTER_ENABLED_SETTING, true);
+
+    if (!this.matter) {
+      this.matter = new MatterBridge(getDeviceService());
+    }
+
+    if (!this.matter.isRunning) {
+      try {
+        await this.matter.start();
+      } catch (error) {
+        console.error("[Integrations] Matter start failed:", error);
+        // Keep setting enabled so user can retry / see error on status page
+      }
+    }
+
+    return this.getMatterStatus();
+  }
+
+  async disableMatter(): Promise<MatterBridgeStatus> {
+    getDatabase().setBoolSetting(MATTER_ENABLED_SETTING, false);
+    if (this.matter) {
+      await this.matter.stop();
+      this.matter = null;
+    }
+    return this.getMatterStatus();
+  }
+
+  /**
+   * Updates the advertised vendor/product IDs. These must match the Matter
+   * integration registered in the Google Home Developer Console.
+   * Restarts the bridge (and clears fabrics) so the new identity takes effect.
+   */
+  async setMatterIdentity(vendorId: number, productId: number): Promise<MatterBridgeStatus> {
+    const wasEnabled = this.isMatterEnabled();
+
+    // Identity is baked into commissioned fabrics, so start clean. Erase while
+    // the node is still up; it owns its storage handles.
+    if (this.matter?.isRunning) {
+      await this.matter.factoryReset();
+    }
+
+    if (this.matter) {
+      await this.matter.stop();
+      this.matter = null;
+    }
+
+    setMatterIdentity(vendorId, productId);
+
+    if (wasEnabled) {
+      return this.enableMatter();
+    }
+    return this.getMatterStatus();
+  }
+
+  /**
+   * Clears commissioned fabrics so the bridge can be paired again.
+   */
+  async resetMatterCommissioning(): Promise<MatterBridgeStatus> {
+    // While the node is running it owns its storage handles, so ask Matter to
+    // erase itself instead of deleting files underneath it.
+    if (this.matter?.isRunning) {
+      await this.matter.factoryReset();
+      console.log("[Matter] Commissioning state reset");
+      return this.getMatterStatus();
+    }
+
+    const wasEnabled = this.isMatterEnabled();
+
+    if (this.matter) {
+      await this.matter.stop();
+      this.matter = null;
+    }
+
+    await resetCommissioningState();
+    console.log("[Matter] Commissioning state reset");
+
+    if (wasEnabled) {
+      return this.enableMatter();
+    }
+    return this.getMatterStatus();
+  }
+
+  /**
+   * Sets or clears a per-device Matter kind override.
+   */
+  async setDeviceKind(
+    deviceId: string,
+    kind: MatterDeviceKind | null
+  ): Promise<MatterBridgeStatus> {
+    if (this.matter) {
+      return this.matter.setDeviceKind(deviceId, kind);
+    }
+
+    const device = getDeviceService()
+      .listDevices()
+      .find((d) => d.id === deviceId);
+    if (!device) {
+      throw new Error(`Device not found: ${deviceId}`);
+    }
+    setKindOverride(deviceId, kind);
+    return this.getMatterStatus();
+  }
+
+  async stopAll(): Promise<void> {
+    if (this.matter) {
+      await this.matter.stop();
+      this.matter = null;
+    }
+  }
+}
+
+export { DEFAULT_PRODUCT_ID, DEFAULT_VENDOR_ID };
+
+let manager: IntegrationManager | null = null;
+
+export function getIntegrationManager(): IntegrationManager {
+  if (!manager) {
+    manager = new IntegrationManager();
+  }
+  return manager;
+}
+
+export function resetIntegrationManager(): void {
+  manager = null;
+}

--- a/packages/bridge/src/integrations/matter/__tests__/mapper.test.ts
+++ b/packages/bridge/src/integrations/matter/__tests__/mapper.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import { WemoDeviceType } from "../../../wemo/types";
+import {
+  mapWemoTypeToMatter,
+  resolveMatterKind,
+  toMatterEndpointId,
+  toMatterUniqueId,
+} from "../mapper";
+
+describe("mapWemoTypeToMatter", () => {
+  test("maps plugs and switches to plug", () => {
+    expect(mapWemoTypeToMatter(WemoDeviceType.Switch)).toBe("plug");
+    expect(mapWemoTypeToMatter(WemoDeviceType.Mini)).toBe("plug");
+    expect(mapWemoTypeToMatter(WemoDeviceType.Insight)).toBe("plug");
+  });
+
+  test("maps lights and dimmers to light", () => {
+    expect(mapWemoTypeToMatter(WemoDeviceType.LightSwitch)).toBe("light");
+    expect(mapWemoTypeToMatter(WemoDeviceType.Bulb)).toBe("light");
+    expect(mapWemoTypeToMatter(WemoDeviceType.Dimmer)).toBe("light");
+  });
+
+  test("defaults Unknown and unrecognized types to plug for on/off", () => {
+    expect(mapWemoTypeToMatter(WemoDeviceType.Unknown)).toBe("plug");
+    expect(mapWemoTypeToMatter("SomethingElse")).toBe("plug");
+  });
+
+  test("skips motion only", () => {
+    expect(mapWemoTypeToMatter(WemoDeviceType.Motion)).toBe("skip");
+  });
+});
+
+describe("resolveMatterKind", () => {
+  test("uses automatic mapping when no override", () => {
+    const resolved = resolveMatterKind(WemoDeviceType.Switch);
+    expect(resolved).toEqual({ kind: "plug", autoKind: "plug", source: "auto" });
+  });
+
+  test("Unknown auto-maps to plug", () => {
+    const resolved = resolveMatterKind(WemoDeviceType.Unknown);
+    expect(resolved.kind).toBe("plug");
+    expect(resolved.source).toBe("auto");
+  });
+
+  test("override wins over automatic mapping", () => {
+    const resolved = resolveMatterKind(WemoDeviceType.Switch, "light");
+    expect(resolved).toEqual({ kind: "light", autoKind: "plug", source: "override" });
+  });
+
+  test("null or invalid override falls back to auto", () => {
+    expect(resolveMatterKind(WemoDeviceType.Dimmer, null).source).toBe("auto");
+    expect(resolveMatterKind(WemoDeviceType.Dimmer, undefined).kind).toBe("light");
+  });
+});
+
+describe("toMatterEndpointId", () => {
+  test("sanitizes special characters", () => {
+    expect(toMatterEndpointId("uuid:Socket-1_0-ABC")).toBe("uuid_Socket-1_0-ABC");
+  });
+
+  test("handles empty-like input", () => {
+    const id = toMatterEndpointId("!!!");
+    expect(id.startsWith("device_")).toBe(true);
+  });
+});
+
+describe("toMatterUniqueId", () => {
+  test("strips non-alphanumeric", () => {
+    expect(toMatterUniqueId("uuid:Socket-1")).toBe("uuidSocket1");
+  });
+});

--- a/packages/bridge/src/integrations/matter/bridge.ts
+++ b/packages/bridge/src/integrations/matter/bridge.ts
@@ -1,0 +1,521 @@
+/**
+ * Matter Bridge — exposes Open Wemo devices to Google Home / Matter controllers.
+ */
+
+import "@matter/nodejs";
+import { Endpoint, Environment, ServerNode, StorageService, VendorId } from "@matter/main";
+import { BridgedDeviceBasicInformationServer } from "@matter/main/behaviors/bridged-device-basic-information";
+import { OnOffLightDevice } from "@matter/main/devices/on-off-light";
+import { OnOffPlugInUnitDevice } from "@matter/main/devices/on-off-plug-in-unit";
+import { AggregatorEndpoint } from "@matter/main/endpoints/aggregator";
+import type { DeviceService } from "../../device-service";
+import type { SavedDevice } from "../../wemo/types";
+import { getKindOverride, setKindOverride } from "./kinds";
+import {
+  type MatterDeviceKind,
+  type MatterKindSource,
+  resolveMatterKind,
+  toMatterEndpointId,
+  toMatterUniqueId,
+} from "./mapper";
+import { completePendingReset, getMatterStorageDir, getOrCreateCredentials } from "./storage";
+
+/** Default Matter UDP port. */
+export const MATTER_PORT = 5540;
+
+/** Persistence backend for Matter fabric data (see configureStorageDriver). */
+const MATTER_STORAGE_DRIVER = "sqlite";
+
+export interface MatterPairingInfo {
+  qrPairingCode: string;
+  manualPairingCode: string;
+  passcode: number;
+  discriminator: number;
+  commissioned: boolean;
+}
+
+export interface MatterIdentity {
+  vendorId: number;
+  productId: number;
+  /** Hex form shown in the UI, e.g. "0xFFF1" */
+  vendorIdHex: string;
+  productIdHex: string;
+}
+
+export interface MatterDeviceStatus {
+  id: string;
+  name: string;
+  wemoType: string;
+  matterKind: MatterDeviceKind;
+  autoKind: MatterDeviceKind;
+  source: MatterKindSource;
+  /** True when an endpoint is currently advertised on the Matter fabric. */
+  exposed: boolean;
+}
+
+export interface MatterBridgeStatus {
+  running: boolean;
+  commissioned: boolean;
+  deviceCount: number;
+  /** Devices skipped because their type has no Matter on/off equivalent. */
+  skippedCount: number;
+  devices: MatterDeviceStatus[];
+  pairing: MatterPairingInfo | null;
+  identity: MatterIdentity;
+  port: number;
+  storagePath: string;
+  error?: string;
+}
+
+function toHex(value: number): string {
+  return `0x${value.toString(16).toUpperCase().padStart(4, "0")}`;
+}
+
+/**
+ * Selects SQLite for Matter's persistence.
+ *
+ * The default file driver writes each key to `<key>.tmp` and renames it over
+ * the live file. Under Bun on Windows that rename intermittently fails with
+ * EPERM, which aborts commissioning and leaves the Matter environment crashed
+ * so it cannot be restarted in-process. matter.js migrates existing file-based
+ * storage automatically.
+ */
+function configureStorageDriver(): void {
+  try {
+    const storage = Environment.default.get(StorageService);
+    storage.configuredDriver = MATTER_STORAGE_DRIVER;
+    storage.configuredBlobDriver = MATTER_STORAGE_DRIVER;
+  } catch (error) {
+    console.warn("[Matter] Could not select SQLite storage driver, using default:", error);
+  }
+}
+
+/**
+ * Runs a Matter aggregator bridge backed by DeviceService.
+ */
+export class MatterBridge {
+  private server: ServerNode | null = null;
+  private aggregator: Endpoint | null = null;
+  /** Endpoints keyed by WeMo device id (typed loosely for Matter cluster state). */
+  private endpoints = new Map<string, Endpoint>();
+  /** Matter kind currently advertised for each endpoint (for recreate-on-change). */
+  private endpointKinds = new Map<string, MatterDeviceKind>();
+  /** Device IDs currently being updated from DeviceService (avoid feedback loops). */
+  private ignoreMatterWrites = new Set<string>();
+  private unsubscribers: Array<() => void> = [];
+  private lastError: string | undefined;
+  private starting = false;
+
+  constructor(private readonly deviceService: DeviceService) {}
+
+  get isRunning(): boolean {
+    return this.server?.lifecycle.isOnline === true;
+  }
+
+  /**
+   * Starts the Matter bridge and syncs all saved devices.
+   */
+  async start(): Promise<void> {
+    if (this.server || this.starting) {
+      console.log("[Matter] Already started or starting");
+      return;
+    }
+    this.starting = true;
+    this.lastError = undefined;
+
+    try {
+      const storageDir = getMatterStorageDir();
+      const credentials = getOrCreateCredentials();
+
+      await completePendingReset();
+
+      Environment.default.vars.set("path.root", storageDir);
+      configureStorageDriver();
+
+      console.log(`[Matter] Starting bridge (storage: ${storageDir})`);
+
+      this.server = await ServerNode.create({
+        id: "open-wemo",
+        network: { port: MATTER_PORT },
+        commissioning: {
+          passcode: credentials.passcode,
+          discriminator: credentials.discriminator,
+        },
+        productDescription: {
+          name: "Open Wemo",
+          deviceType: AggregatorEndpoint.deviceType,
+        },
+        basicInformation: {
+          vendorName: "Open Wemo",
+          vendorId: VendorId(credentials.vendorId),
+          nodeLabel: "Open Wemo",
+          productName: "Open Wemo Bridge",
+          productLabel: "WeMo Matter Bridge",
+          productId: credentials.productId,
+          serialNumber: credentials.uniqueId.slice(0, 32),
+          uniqueId: credentials.uniqueId,
+        },
+      });
+
+      console.log(
+        `[Matter] Identity: vendorId=${toHex(credentials.vendorId)} productId=${toHex(credentials.productId)}`
+      );
+
+      this.aggregator = new Endpoint(AggregatorEndpoint, { id: "aggregator" });
+      await this.server.add(this.aggregator);
+
+      // Sync existing devices before going online
+      const devices = this.deviceService.listDevices();
+      for (const device of devices) {
+        await this.addDeviceEndpoint(device);
+      }
+
+      this.subscribeToDeviceService();
+      await this.server.start();
+
+      const pairing = this.getPairingInfo();
+      console.log(`[Matter] Bridge online — ${this.endpoints.size} device(s)`);
+      if (pairing && !pairing.commissioned) {
+        console.log(`[Matter] Manual pairing code: ${pairing.manualPairingCode}`);
+        console.log(`[Matter] QR pairing code: ${pairing.qrPairingCode}`);
+      }
+    } catch (error) {
+      this.lastError = error instanceof Error ? error.message : String(error);
+      console.error("[Matter] Failed to start:", error);
+      await this.cleanup();
+      throw error;
+    } finally {
+      this.starting = false;
+    }
+  }
+
+  /**
+   * Erases commissioned fabrics via the Matter factory-reset flow.
+   *
+   * Preferred over deleting storage files: the node keeps its own handles, so
+   * on-disk cleanup from another code path fails while the process is alive.
+   */
+  async factoryReset(): Promise<void> {
+    if (!this.server) {
+      throw new Error("Matter bridge is not running");
+    }
+    console.log("[Matter] Performing factory reset...");
+    await this.server.erase();
+    console.log("[Matter] Factory reset complete");
+  }
+
+  /**
+   * Stops the Matter bridge.
+   */
+  async stop(): Promise<void> {
+    console.log("[Matter] Stopping bridge...");
+    await this.cleanup();
+    console.log("[Matter] Bridge stopped");
+  }
+
+  private async cleanup(): Promise<void> {
+    for (const unsub of this.unsubscribers) {
+      unsub();
+    }
+    this.unsubscribers = [];
+    this.endpoints.clear();
+    this.endpointKinds.clear();
+    this.ignoreMatterWrites.clear();
+
+    if (this.server) {
+      try {
+        await this.server.close();
+      } catch (error) {
+        console.error("[Matter] Error closing server:", error);
+      }
+    }
+    this.server = null;
+    this.aggregator = null;
+  }
+
+  /**
+   * Lists Matter kind status for every saved WeMo device.
+   */
+  listDeviceStatuses(): MatterDeviceStatus[] {
+    return this.deviceService.listDevices().map((device) => {
+      const override = getKindOverride(device.id);
+      const resolved = resolveMatterKind(device.deviceType, override);
+      return {
+        id: device.id,
+        name: device.name,
+        wemoType: device.deviceType,
+        matterKind: resolved.kind,
+        autoKind: resolved.autoKind,
+        source: resolved.source,
+        exposed: this.endpoints.has(device.id),
+      };
+    });
+  }
+
+  getStatus(): MatterBridgeStatus {
+    const credentials = getOrCreateCredentials();
+    const devices = this.listDeviceStatuses();
+    return {
+      running: this.isRunning,
+      commissioned: this.server?.lifecycle.isCommissioned ?? false,
+      deviceCount: this.endpoints.size,
+      skippedCount: devices.filter((d) => d.matterKind === "skip").length,
+      devices,
+      pairing: this.getPairingInfo(),
+      identity: {
+        vendorId: credentials.vendorId,
+        productId: credentials.productId,
+        vendorIdHex: toHex(credentials.vendorId),
+        productIdHex: toHex(credentials.productId),
+      },
+      port: MATTER_PORT,
+      storagePath: getMatterStorageDir(),
+      error: this.lastError,
+    };
+  }
+
+  /**
+   * Sets or clears a per-device Matter kind override and recreates the endpoint
+   * when the bridge is running (device type is fixed at endpoint creation).
+   */
+  async setDeviceKind(
+    deviceId: string,
+    kind: MatterDeviceKind | null
+  ): Promise<MatterBridgeStatus> {
+    const device = this.deviceService.listDevices().find((d) => d.id === deviceId);
+    if (!device) {
+      throw new Error(`Device not found: ${deviceId}`);
+    }
+
+    setKindOverride(deviceId, kind);
+
+    if (this.aggregator) {
+      await this.removeDeviceEndpoint(deviceId);
+      await this.addDeviceEndpoint(device);
+    }
+
+    return this.getStatus();
+  }
+
+  getPairingInfo(): MatterPairingInfo | null {
+    if (!this.server) return null;
+    try {
+      const credentials = getOrCreateCredentials();
+      const codes = this.server.state.commissioning.pairingCodes;
+      return {
+        qrPairingCode: codes.qrPairingCode,
+        manualPairingCode: codes.manualPairingCode,
+        passcode: credentials.passcode,
+        discriminator: credentials.discriminator,
+        commissioned: this.server.lifecycle.isCommissioned,
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  private subscribeToDeviceService(): void {
+    this.unsubscribers.push(
+      this.deviceService.events.on("deviceAdded", (device) => {
+        this.addDeviceEndpoint(device).catch((err) =>
+          console.error(`[Matter] Failed to add device ${device.id}:`, err)
+        );
+      })
+    );
+
+    this.unsubscribers.push(
+      this.deviceService.events.on("deviceRemoved", ({ id }) => {
+        this.removeDeviceEndpoint(id).catch((err) =>
+          console.error(`[Matter] Failed to remove device ${id}:`, err)
+        );
+      })
+    );
+
+    this.unsubscribers.push(
+      this.deviceService.events.on("deviceUpdated", (device) => {
+        this.updateDeviceEndpoint(device).catch((err) =>
+          console.error(`[Matter] Failed to update device ${device.id}:`, err)
+        );
+      })
+    );
+
+    this.unsubscribers.push(
+      this.deviceService.events.on("stateChanged", ({ id, isOn, source }) => {
+        if (source === "matter") return;
+        this.applyExternalState(id, isOn).catch((err) =>
+          console.error(`[Matter] Failed to sync state for ${id}:`, err)
+        );
+      })
+    );
+  }
+
+  private async addDeviceEndpoint(device: SavedDevice): Promise<void> {
+    if (!this.aggregator) return;
+
+    const resolved = resolveMatterKind(device.deviceType, getKindOverride(device.id));
+    const kind = resolved.kind;
+    if (kind === "skip") {
+      console.log(`[Matter] Skipping device (kind=skip): ${device.deviceType} (${device.name})`);
+      return;
+    }
+
+    if (this.endpoints.has(device.id)) {
+      await this.updateDeviceEndpoint(device);
+      return;
+    }
+
+    const endpointId = toMatterEndpointId(device.id);
+    const uniqueId = toMatterUniqueId(device.id);
+    // Actuator types only — never OnOffLightSwitch (Google shows no controls).
+    const DeviceType =
+      kind === "plug"
+        ? OnOffPlugInUnitDevice.with(BridgedDeviceBasicInformationServer)
+        : OnOffLightDevice.with(BridgedDeviceBasicInformationServer);
+
+    // Poll initial state (best-effort)
+    let initialOn = false;
+    let reachable = true;
+    try {
+      const status = await this.deviceService.getState(device.id);
+      if (status.isOnline && status.state !== undefined) {
+        initialOn = status.state === 1 || status.state === 8;
+      } else {
+        reachable = false;
+      }
+    } catch {
+      reachable = false;
+    }
+
+    const endpoint = new Endpoint(DeviceType, {
+      id: endpointId,
+      bridgedDeviceBasicInformation: {
+        nodeLabel: truncateLabel(device.name),
+        productName: truncateLabel(device.name),
+        productLabel: truncateLabel(`${device.deviceType}`),
+        serialNumber: uniqueId.slice(0, 32),
+        uniqueId,
+        reachable,
+      },
+      onOff: { onOff: initialOn },
+    });
+
+    await this.aggregator.add(endpoint);
+    this.endpoints.set(device.id, endpoint);
+    this.endpointKinds.set(device.id, kind);
+
+    endpoint.events.onOff.onOff$Changed.on((value: boolean) => {
+      void this.handleMatterOnOffChange(device.id, value);
+    });
+
+    console.log(`[Matter] Added endpoint for "${device.name}" (${kind}, ${resolved.source})`);
+  }
+
+  private async removeDeviceEndpoint(deviceId: string): Promise<void> {
+    const endpoint = this.endpoints.get(deviceId);
+    if (!endpoint) {
+      this.endpointKinds.delete(deviceId);
+      return;
+    }
+    try {
+      await endpoint.delete();
+    } catch (error) {
+      console.error(`[Matter] Error deleting endpoint ${deviceId}:`, error);
+    }
+    this.endpoints.delete(deviceId);
+    this.endpointKinds.delete(deviceId);
+    console.log(`[Matter] Removed endpoint for ${deviceId}`);
+  }
+
+  private async updateDeviceEndpoint(device: SavedDevice): Promise<void> {
+    const endpoint = this.endpoints.get(device.id);
+    const resolved = resolveMatterKind(device.deviceType, getKindOverride(device.id));
+
+    // Kind changed (or became skip) — recreate; device type is fixed at creation.
+    if (!endpoint || this.endpointKinds.get(device.id) !== resolved.kind) {
+      if (endpoint) {
+        await this.removeDeviceEndpoint(device.id);
+      }
+      if (resolved.kind !== "skip") {
+        await this.addDeviceEndpoint(device);
+      }
+      return;
+    }
+
+    try {
+      await endpoint.setStateOf(BridgedDeviceBasicInformationServer, {
+        nodeLabel: truncateLabel(device.name),
+        productName: truncateLabel(device.name),
+      });
+    } catch (error) {
+      console.error(`[Matter] Failed to rename endpoint ${device.id}:`, error);
+    }
+  }
+
+  private async handleMatterOnOffChange(deviceId: string, value: boolean): Promise<void> {
+    if (this.ignoreMatterWrites.has(deviceId)) {
+      return;
+    }
+
+    console.log(`[Matter] Controller set ${deviceId} → ${value ? "ON" : "OFF"}`);
+    try {
+      if (value) {
+        await this.deviceService.setOn(deviceId, "matter");
+      } else {
+        await this.deviceService.setOff(deviceId, "matter");
+      }
+      await this.setReachable(deviceId, true);
+    } catch (error) {
+      console.error(`[Matter] Failed to control WeMo device ${deviceId}:`, error);
+      await this.setReachable(deviceId, false);
+      // Revert Matter attribute to previous WeMo-side truth if possible
+      try {
+        const status = await this.deviceService.getState(deviceId);
+        if (status.isOnline && status.state !== undefined) {
+          await this.applyExternalState(deviceId, status.state === 1 || status.state === 8);
+        }
+      } catch {
+        // ignore
+      }
+    }
+  }
+
+  private async applyExternalState(deviceId: string, isOn: boolean): Promise<void> {
+    const endpoint = this.endpoints.get(deviceId);
+    if (!endpoint) return;
+
+    // Cluster state typing is endpoint-definition-dependent; cast for OnOff devices.
+    const state = endpoint.state as { onOff?: { onOff?: boolean } };
+    const current = state.onOff?.onOff;
+    if (current === isOn) {
+      await this.setReachable(deviceId, true);
+      return;
+    }
+
+    this.ignoreMatterWrites.add(deviceId);
+    try {
+      await endpoint.set({ onOff: { onOff: isOn } } as never);
+      await this.setReachable(deviceId, true);
+    } catch (error) {
+      console.error(`[Matter] Failed to apply external state for ${deviceId}:`, error);
+    } finally {
+      this.ignoreMatterWrites.delete(deviceId);
+    }
+  }
+
+  private async setReachable(deviceId: string, reachable: boolean): Promise<void> {
+    const endpoint = this.endpoints.get(deviceId);
+    if (!endpoint) return;
+    try {
+      const current = endpoint.stateOf(BridgedDeviceBasicInformationServer).reachable;
+      if (current === reachable) return;
+      await endpoint.setStateOf(BridgedDeviceBasicInformationServer, { reachable });
+    } catch {
+      // ignore
+    }
+  }
+}
+
+function truncateLabel(value: string, max = 32): string {
+  if (value.length <= max) return value;
+  return value.slice(0, max);
+}

--- a/packages/bridge/src/integrations/matter/commissioning.ts
+++ b/packages/bridge/src/integrations/matter/commissioning.ts
@@ -1,0 +1,216 @@
+/**
+ * Matter commissioning page / QR helpers.
+ */
+
+import QRCode from "qrcode";
+import type { MatterIdentity, MatterPairingInfo } from "./bridge";
+
+/**
+ * Generates a data-URL QR code for a Matter pairing payload.
+ */
+export async function generatePairingQrDataUrl(qrPairingCode: string): Promise<string> {
+  return QRCode.toDataURL(qrPairingCode, {
+    errorCorrectionLevel: "M",
+    margin: 2,
+    width: 280,
+    color: { dark: "#000000", light: "#ffffff" },
+  });
+}
+
+/**
+ * HTML page for linking Open Wemo to Google Home via Matter.
+ */
+export async function generateMatterPageHtml(options: {
+  enabled: boolean;
+  running: boolean;
+  pairing: MatterPairingInfo | null;
+  error?: string;
+  deviceCount: number;
+  identity: MatterIdentity;
+}): Promise<string> {
+  const { enabled, running, pairing, error, deviceCount, identity } = options;
+
+  let qrImg = "";
+  if (pairing?.qrPairingCode) {
+    const dataUrl = await generatePairingQrDataUrl(pairing.qrPairingCode);
+    qrImg = `<img class="qr" src="${dataUrl}" alt="Matter pairing QR code" width="280" height="280" />`;
+  }
+
+  const statusBadge = !enabled
+    ? `<span class="badge badge-off">Disabled</span>`
+    : running
+      ? `<span class="badge badge-on">Running</span>`
+      : `<span class="badge badge-warn">Starting / Error</span>`;
+
+  const commissionedBadge = pairing?.commissioned
+    ? `<span class="badge badge-on">Linked to a controller</span>`
+    : `<span class="badge badge-warn">Not commissioned yet</span>`;
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Link to Google Home — Open Wemo</title>
+  <link rel="stylesheet" href="/css/style.css" />
+  <style>
+    .matter-page { max-width: 520px; margin: 0 auto; padding: 24px 16px 48px; }
+    .matter-page h1 { font-size: 1.5rem; margin-bottom: 8px; }
+    .matter-page .lead { color: var(--text-secondary, #9ca3af); margin-bottom: 20px; }
+    .status-row { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 20px; }
+    .badge { display: inline-block; padding: 4px 10px; border-radius: 999px; font-size: 0.8rem; font-weight: 600; }
+    .badge-on { background: #14532d; color: #86efac; }
+    .badge-off { background: #3f3f46; color: #d4d4d8; }
+    .badge-warn { background: #713f12; color: #fde68a; }
+    .card {
+      background: var(--card-bg, #1f2937);
+      border-radius: 12px;
+      padding: 20px;
+      margin-bottom: 16px;
+    }
+    .qr-wrap { text-align: center; margin: 16px 0; }
+    .qr { border-radius: 8px; background: #fff; padding: 8px; }
+    .code {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 1.25rem;
+      letter-spacing: 0.08em;
+      text-align: center;
+      padding: 12px;
+      background: #111827;
+      border-radius: 8px;
+      margin: 8px 0 0;
+      word-break: break-all;
+    }
+    .steps { padding-left: 1.2rem; line-height: 1.6; }
+    .steps li { margin-bottom: 8px; }
+    .actions { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 16px; }
+    .error { color: #fca5a5; margin: 12px 0; }
+    .muted { color: var(--text-secondary, #9ca3af); font-size: 0.9rem; }
+    button.btn-primary, a.btn-primary {
+      background: #2563eb; color: #fff; border: none; border-radius: 8px;
+      padding: 10px 16px; font-weight: 600; cursor: pointer; text-decoration: none; display: inline-block;
+    }
+    button.btn-danger {
+      background: #7f1d1d; color: #fecaca; border: none; border-radius: 8px;
+      padding: 10px 16px; font-weight: 600; cursor: pointer;
+    }
+  </style>
+</head>
+<body data-theme="dark">
+  <main class="matter-page">
+    <h1>Link to Google Home</h1>
+    <p class="lead">
+      Open Wemo can appear in Google Home as a Matter bridge.
+      Control stays on your local network — no cloud account required.
+    </p>
+
+    <div class="status-row">
+      ${statusBadge}
+      ${commissionedBadge}
+      <span class="badge badge-off">${deviceCount} device(s) exposed</span>
+    </div>
+
+    ${error ? `<p class="error">${escapeHtml(error)}</p>` : ""}
+
+    <div class="card">
+      <h2 style="margin-top:0;font-size:1.1rem;">Enable Matter Bridge</h2>
+      <p class="muted">When enabled, Open Wemo advertises itself on your LAN for Matter commissioning.</p>
+      <div class="actions">
+        ${
+          enabled
+            ? `<button class="btn-danger" id="btn-disable">Disable Matter</button>
+               <a class="btn-primary" href="/matter">Refresh status</a>`
+            : `<button class="btn-primary" id="btn-enable">Enable Matter</button>`
+        }
+      </div>
+    </div>
+
+    ${
+      enabled && pairing
+        ? `
+    <div class="card">
+      <h2 style="margin-top:0;font-size:1.1rem;">Pairing</h2>
+      ${
+        pairing.commissioned
+          ? `<p>This bridge is already commissioned to a Matter fabric (e.g. Google Home).
+             Devices should appear in the Google Home app. To re-pair, remove “Open Wemo”
+             from Google Home first, then scan the QR again.</p>`
+          : `<p>In the <strong>Google Home</strong> app: Devices → Add → Matter-enabled device → Scan QR code.</p>
+             <div class="qr-wrap">${qrImg}</div>
+             <p class="muted" style="text-align:center">Or enter this setup code manually:</p>
+             <div class="code">${escapeHtml(pairing.manualPairingCode)}</div>`
+      }
+    </div>`
+        : ""
+    }
+
+    <div class="card">
+      <h2 style="margin-top:0;font-size:1.1rem;">Google Home requires a one-time registration</h2>
+      <p>
+        Google only commissions <em>uncertified</em> Matter devices that are registered as a
+        Matter integration in the
+        <a href="https://console.home.google.com/projects" target="_blank" rel="noopener">Google Home Developer Console</a>.
+        Without it, Google Home finds the bridge but stops with “Couldn’t find device”.
+      </p>
+      <ol class="steps">
+        <li>Create a project → <strong>Add integration</strong> → <strong>Matter</strong>.</li>
+        <li>Enter Vendor ID <code>${escapeHtml(identity.vendorIdHex)}</code> and Product ID <code>${escapeHtml(identity.productIdHex)}</code>.</li>
+        <li>Save, then sign in to Google Home with the same account that owns the project.</li>
+      </ol>
+      <p class="muted">
+        Apple Home and Amazon Alexa pair without this step — they just show an “uncertified accessory” warning.
+      </p>
+    </div>
+
+    <div class="card">
+      <h2 style="margin-top:0;font-size:1.1rem;">Steps</h2>
+      <ol class="steps">
+        <li>Make sure your phone is on the same Wi‑Fi as this computer (2.4/5 GHz on one LAN, no guest/AP isolation).</li>
+        <li>Enable the Matter bridge above (and keep Open Wemo running).</li>
+        <li>Open Google Home → Add → Matter-enabled device.</li>
+        <li>Scan the QR code (or type the setup code).</li>
+        <li>Assign rooms to your WeMo switches and plugs.</li>
+      </ol>
+      <p class="muted">
+        Android commissioning can fail with “Something went wrong” due to a Google bug that omits
+        the country code — pairing once from the Google Home app on an iPhone works around it.
+      </p>
+      <div class="actions">
+        <button class="btn-danger" id="btn-reset">Reset pairing</button>
+      </div>
+      <p class="muted">
+        Reset clears saved fabrics so you can commission again after a failed attempt.
+      </p>
+    </div>
+
+    <p><a href="/">← Back to Open Wemo</a></p>
+  </main>
+  <script>
+    async function post(path) {
+      const res = await fetch(path, { method: "POST", headers: { "Content-Type": "application/json" }, body: "{}" });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        alert(data.message || data.error || "Request failed");
+        return;
+      }
+      location.reload();
+    }
+    document.getElementById("btn-enable")?.addEventListener("click", () => post("/api/integrations/matter/enable"));
+    document.getElementById("btn-disable")?.addEventListener("click", () => post("/api/integrations/matter/disable"));
+    document.getElementById("btn-reset")?.addEventListener("click", () => {
+      if (confirm("Clear Matter pairing? You will need to remove Open Wemo from Google Home and pair again.")) {
+        post("/api/integrations/matter/reset");
+      }
+    });
+  </script>
+</body>
+</html>`;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}

--- a/packages/bridge/src/integrations/matter/kinds.ts
+++ b/packages/bridge/src/integrations/matter/kinds.ts
@@ -1,0 +1,66 @@
+/**
+ * Optional per-device Matter kind overrides (SQLite settings).
+ */
+
+import { getDatabase } from "../../db";
+import type { MatterDeviceKind } from "./mapper";
+
+export const MATTER_DEVICE_KINDS_SETTING = "matter_device_kinds";
+
+type KindMap = Record<string, MatterDeviceKind>;
+
+function isMatterKind(value: unknown): value is MatterDeviceKind {
+  return value === "plug" || value === "light" || value === "skip";
+}
+
+/**
+ * Loads the override map from settings. Invalid entries are ignored.
+ */
+export function getKindOverrides(): KindMap {
+  const raw = getDatabase().getSetting(MATTER_DEVICE_KINDS_SETTING);
+  if (!raw) return {};
+
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {};
+    }
+
+    const result: KindMap = {};
+    for (const [id, kind] of Object.entries(parsed as Record<string, unknown>)) {
+      if (typeof id === "string" && id.length > 0 && isMatterKind(kind)) {
+        result[id] = kind;
+      }
+    }
+    return result;
+  } catch {
+    return {};
+  }
+}
+
+function saveKindOverrides(map: KindMap): void {
+  getDatabase().setSetting(MATTER_DEVICE_KINDS_SETTING, JSON.stringify(map));
+}
+
+/**
+ * Returns the override for a device, or null if none.
+ */
+export function getKindOverride(deviceId: string): MatterDeviceKind | null {
+  return getKindOverrides()[deviceId] ?? null;
+}
+
+/**
+ * Sets or clears a per-device Matter kind override.
+ * Pass null to clear and fall back to automatic mapping.
+ */
+export function setKindOverride(deviceId: string, kind: MatterDeviceKind | null): void {
+  const map = getKindOverrides();
+  if (kind === null) {
+    delete map[deviceId];
+  } else if (!isMatterKind(kind)) {
+    throw new Error(`Invalid Matter kind: ${String(kind)}`);
+  } else {
+    map[deviceId] = kind;
+  }
+  saveKindOverrides(map);
+}

--- a/packages/bridge/src/integrations/matter/mapper.ts
+++ b/packages/bridge/src/integrations/matter/mapper.ts
@@ -1,0 +1,93 @@
+/**
+ * Maps WeMo device types to Matter endpoint kinds.
+ *
+ * Controllers (especially Google Home) choose UI controls from the Matter
+ * device type ID. We only use actuator types with an OnOff cluster:
+ * On/Off Plug-in Unit and On/Off Light — never On/Off Light Switch (0x0103),
+ * which Google treats as a controller with no on/off UI.
+ */
+
+import { WemoDeviceType } from "../../wemo/types";
+
+/** Matter device kind used when creating bridged endpoints. */
+export type MatterDeviceKind = "plug" | "light" | "skip";
+
+export type MatterKindSource = "auto" | "override";
+
+export interface ResolvedMatterKind {
+  kind: MatterDeviceKind;
+  /** Kind from WeMo type alone (before override). */
+  autoKind: MatterDeviceKind;
+  source: MatterKindSource;
+}
+
+/**
+ * Returns the automatic Matter endpoint kind for a WeMo device type.
+ *
+ * Unknown defaults to plug so devices still get on/off in controllers.
+ * Motion is skipped (no on/off actuator).
+ */
+export function mapWemoTypeToMatter(deviceType: WemoDeviceType | string): MatterDeviceKind {
+  switch (deviceType) {
+    case WemoDeviceType.Switch:
+    case WemoDeviceType.Mini:
+    case WemoDeviceType.Insight:
+    case WemoDeviceType.Unknown:
+      return "plug";
+    case WemoDeviceType.LightSwitch:
+    case WemoDeviceType.Bulb:
+    case WemoDeviceType.Dimmer:
+      // Dimmer maps to on/off light until brightness is implemented
+      return "light";
+    case WemoDeviceType.Motion:
+      return "skip";
+    default:
+      // Future / unrecognized types: prefer on/off over dropping the device
+      return "plug";
+  }
+}
+
+/**
+ * Resolves the effective Matter kind for a device.
+ *
+ * Priority: user override → automatic map from WeMo type.
+ */
+export function resolveMatterKind(
+  deviceType: WemoDeviceType | string,
+  override?: MatterDeviceKind | null
+): ResolvedMatterKind {
+  const autoKind = mapWemoTypeToMatter(deviceType);
+  if (override === "plug" || override === "light" || override === "skip") {
+    return { kind: override, autoKind, source: "override" };
+  }
+  return { kind: autoKind, autoKind, source: "auto" };
+}
+
+/**
+ * Sanitizes a WeMo device ID into a Matter-safe endpoint id / uniqueId fragment.
+ * Matter uniqueId should be alphanumeric and reasonably short.
+ */
+export function toMatterEndpointId(deviceId: string): string {
+  // Keep readable prefix; strip characters that break endpoint ids
+  const cleaned = deviceId.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 64);
+  // Reject empty or punctuation-only results
+  if (/[a-zA-Z0-9]/.test(cleaned)) {
+    return cleaned;
+  }
+  return `device_${hashString(deviceId)}`;
+}
+
+/**
+ * Creates a Matter uniqueId (alphanumeric, no hyphens preferred for some controllers).
+ */
+export function toMatterUniqueId(deviceId: string): string {
+  return deviceId.replace(/[^a-zA-Z0-9]/g, "").slice(0, 32) || `ow${hashString(deviceId)}`;
+}
+
+function hashString(input: string): string {
+  let hash = 0;
+  for (let i = 0; i < input.length; i++) {
+    hash = (hash * 31 + input.charCodeAt(i)) >>> 0;
+  }
+  return hash.toString(16);
+}

--- a/packages/bridge/src/integrations/matter/storage.ts
+++ b/packages/bridge/src/integrations/matter/storage.ts
@@ -1,0 +1,177 @@
+/**
+ * Matter storage paths and commissioning credential helpers.
+ */
+
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { getAppDataDir } from "../../db";
+
+/** Matter fabric / node storage directory under app data. */
+export function getMatterStorageDir(): string {
+  const dir = join(getAppDataDir(), "matter");
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+  return dir;
+}
+
+/**
+ * Matter test vendor IDs allocated by the Connectivity Standards Alliance.
+ * Google Home only commissions uncertified devices whose VID/PID pair is
+ * registered as a Matter integration in the Google Home Developer Console.
+ */
+export const TEST_VENDOR_IDS = [0xfff1, 0xfff2, 0xfff3, 0xfff4] as const;
+
+/** Default identity used until the user configures their own VID/PID. */
+export const DEFAULT_VENDOR_ID = 0xfff1;
+export const DEFAULT_PRODUCT_ID = 0x8001;
+
+export interface MatterCredentials {
+  passcode: number;
+  discriminator: number;
+  uniqueId: string;
+  vendorId: number;
+  productId: number;
+}
+
+const CREDENTIALS_FILE = "credentials.json";
+
+function credentialsPath(): string {
+  return join(getMatterStorageDir(), CREDENTIALS_FILE);
+}
+
+function writeCredentials(credentials: MatterCredentials): MatterCredentials {
+  writeFileSync(credentialsPath(), JSON.stringify(credentials, null, 2), "utf-8");
+  return credentials;
+}
+
+/**
+ * Loads or creates stable Matter commissioning credentials.
+ */
+export function getOrCreateCredentials(): MatterCredentials {
+  const path = credentialsPath();
+  if (existsSync(path)) {
+    try {
+      const parsed = JSON.parse(readFileSync(path, "utf-8")) as Partial<MatterCredentials>;
+      if (
+        typeof parsed.passcode === "number" &&
+        typeof parsed.discriminator === "number" &&
+        typeof parsed.uniqueId === "string"
+      ) {
+        // Backfill identity fields added after the first release
+        return {
+          passcode: parsed.passcode,
+          discriminator: parsed.discriminator,
+          uniqueId: parsed.uniqueId,
+          vendorId: parsed.vendorId ?? DEFAULT_VENDOR_ID,
+          productId: parsed.productId ?? DEFAULT_PRODUCT_ID,
+        };
+      }
+    } catch {
+      // regenerate below
+    }
+  }
+
+  return writeCredentials({
+    // Standard Matter development setup passcode (8 digits, spec-valid)
+    passcode: 20202021,
+    // Discriminator 0-4095
+    discriminator: 3840,
+    uniqueId: `openwemo${Date.now().toString(16)}`.slice(0, 32),
+    vendorId: DEFAULT_VENDOR_ID,
+    productId: DEFAULT_PRODUCT_ID,
+  });
+}
+
+/**
+ * Updates the vendor/product identity advertised during commissioning.
+ * Must match the Matter integration registered in the Google Home Developer Console.
+ */
+export function setMatterIdentity(vendorId: number, productId: number): MatterCredentials {
+  if (!Number.isInteger(vendorId) || vendorId < 1 || vendorId > 0xfff4) {
+    throw new Error("Invalid vendorId: must be an integer between 1 and 65524 (0xFFF4)");
+  }
+  if (!Number.isInteger(productId) || productId < 1 || productId > 0xffff) {
+    throw new Error("Invalid productId: must be an integer between 1 and 65535");
+  }
+
+  const current = getOrCreateCredentials();
+  return writeCredentials({ ...current, vendorId, productId });
+}
+
+/** Marker written when storage could not be deleted immediately. */
+const RESET_MARKER = ".reset-pending";
+
+function protectedEntry(entry: string): boolean {
+  return entry === CREDENTIALS_FILE || entry === RESET_MARKER;
+}
+
+/**
+ * Deletes Matter storage entries, retrying while the OS still holds handles.
+ * Windows keeps SQLite files locked briefly after close.
+ *
+ * @returns entries that could not be removed
+ */
+async function removeStorageEntries(dir: string, attempts = 20): Promise<string[]> {
+  let remaining = readdirSync(dir).filter((entry) => !protectedEntry(entry));
+
+  for (let attempt = 0; attempt < attempts && remaining.length > 0; attempt++) {
+    if (attempt > 0) {
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    }
+
+    remaining = remaining.filter((entry) => {
+      try {
+        rmSync(join(dir, entry), { recursive: true, force: true });
+        return false;
+      } catch {
+        return true;
+      }
+    });
+  }
+
+  return remaining;
+}
+
+/**
+ * Deletes commissioned fabric data so the bridge can be paired again.
+ * Commissioning credentials (passcode/discriminator) are preserved so the
+ * QR code stays the same.
+ *
+ * @returns true if storage was fully cleared, false if leftovers were deferred
+ *   to the next start (see {@link completePendingReset})
+ */
+export async function resetCommissioningState(): Promise<boolean> {
+  const dir = getMatterStorageDir();
+  const preserved = getOrCreateCredentials();
+
+  const failed = await removeStorageEntries(dir);
+  if (failed.length > 0) {
+    console.warn(`[Matter] Storage still locked, deferring cleanup of: ${failed.join(", ")}`);
+    writeFileSync(join(dir, RESET_MARKER), new Date().toISOString(), "utf-8");
+  }
+
+  writeCredentials(preserved);
+  return failed.length === 0;
+}
+
+/**
+ * Finishes a reset that could not complete because storage was locked.
+ * Call before opening Matter storage.
+ */
+export async function completePendingReset(): Promise<void> {
+  const dir = getMatterStorageDir();
+  const marker = join(dir, RESET_MARKER);
+  if (!existsSync(marker)) {
+    return;
+  }
+
+  const failed = await removeStorageEntries(dir);
+  if (failed.length > 0) {
+    console.warn(`[Matter] Could not clear Matter storage: ${failed.join(", ")}`);
+    return;
+  }
+
+  rmSync(marker, { force: true });
+  console.log("[Matter] Completed deferred commissioning reset");
+}

--- a/packages/bridge/src/main.ts
+++ b/packages/bridge/src/main.ts
@@ -2,7 +2,9 @@ import { existsSync, unlinkSync } from "node:fs";
 import { platform } from "node:os";
 import { join } from "node:path";
 import { closeDatabase, getAppDataDir, getDatabase } from "./db";
+import { getDeviceService } from "./device-service";
 import { handleAutoInstall } from "./install";
+import { getIntegrationManager } from "./integrations";
 import { type ServerInstance, startServer } from "./server";
 import { getSavedAutostartPreference, setAutostart, syncAutostart } from "./tray/autostart";
 import { type AppTray, createTray } from "./tray/index";
@@ -137,7 +139,15 @@ async function initialize(): Promise<void> {
   // Step 6: Start keep-alive service for Insight devices with low-power loads
   state.keepAlive = startKeepAlive();
 
-  // Step 6: Show first-launch setup if needed
+  // Step 7: Start Matter bridge if enabled
+  console.log("[Main] Checking Matter integration...");
+  try {
+    await getIntegrationManager().startFromSettings();
+  } catch (error) {
+    console.error("[Main] Matter integration failed to start:", error);
+  }
+
+  // Step 8: Show first-launch setup if needed
   if (shouldShowWelcome()) {
     console.log("[Main] First launch detected, opening device setup page...");
     openInBrowser(`${getServerUrl(DEFAULT_PORT)}/setup`);
@@ -151,7 +161,8 @@ async function initialize(): Promise<void> {
  * Creates the system tray with menu.
  */
 async function createSystemTray(): Promise<void> {
-  const menuItems = createMenuItems(state.startOnLogin);
+  const matterEnabled = getIntegrationManager().isMatterEnabled();
+  const menuItems = createMenuItems(state.startOnLogin, matterEnabled);
 
   state.tray = createTray({
     tooltip: "Open Wemo - WeMo Device Controller",
@@ -176,6 +187,22 @@ async function createSystemTray(): Promise<void> {
           console.log("[Main] Opening device setup page...");
           openInBrowser(`${getServerUrl(DEFAULT_PORT)}/setup`);
         },
+        onLinkGoogleHome: () => {
+          console.log("[Main] Opening Google Home / Matter page...");
+          openInBrowser(`${getServerUrl(DEFAULT_PORT)}/matter`);
+        },
+        onMatterToggle: async (enabled: boolean) => {
+          console.log(`[Main] Toggling Matter bridge: ${enabled}`);
+          const mgr = getIntegrationManager();
+          if (enabled) {
+            await mgr.enableMatter();
+          } else {
+            await mgr.disableMatter();
+          }
+          state.tray?.updateMenuItem(MenuItemIds.MATTER_TOGGLE, {
+            checked: mgr.isMatterEnabled(),
+          });
+        },
         onDiscover: async () => {
           console.log("[Main] Running device discovery...");
           await runBackgroundDiscovery();
@@ -196,7 +223,8 @@ async function createSystemTray(): Promise<void> {
       () => state.startOnLogin,
       (value) => {
         state.startOnLogin = value;
-      }
+      },
+      () => getIntegrationManager().isMatterEnabled()
     ),
   });
 
@@ -211,26 +239,21 @@ async function runBackgroundDiscovery(): Promise<void> {
     const result = await discoverDevices({ timeout: 5000 });
     console.log(`[Main] Discovery found ${result.devices.length} device(s)`);
 
-    // Save discovered devices to database
     const db = getDatabase();
+    const deviceService = getDeviceService();
+
     for (const device of result.devices) {
       const deviceId = device.serialNumber || `device-${Date.now()}`;
 
       // Check if device exists by ID (serial number) - handles IP changes after re-setup
       const existingById = db.getDeviceById(deviceId);
       if (existingById) {
-        // Device exists - check if IP changed
         if (existingById.host !== device.host || existingById.port !== device.port) {
           console.log(
             `[Main] Device ${device.name} IP changed: ${existingById.host}:${existingById.port} -> ${device.host}:${device.port}`
           );
-          // Update the device with new IP
-          db.saveDevice({
-            ...existingById,
-            host: device.host,
-            port: device.port,
-            updatedAt: new Date().toISOString(),
-          });
+          // Emits deviceUpdated so Matter can stay in sync
+          deviceService.syncDeviceAddress(existingById.id, device.host, device.port);
         } else {
           db.updateLastSeen(existingById.id);
         }
@@ -244,15 +267,13 @@ async function runBackgroundDiscovery(): Promise<void> {
         continue;
       }
 
-      // New device - save it
-      db.saveDevice({
+      // New device - save via DeviceService so Matter receives deviceAdded
+      await deviceService.saveDevice({
         id: deviceId,
         name: device.name,
         deviceType: device.deviceType,
         host: device.host,
         port: device.port,
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
       });
       console.log(`[Main] Saved new device: ${device.name}`);
     }
@@ -272,6 +293,14 @@ async function shutdown(): Promise<void> {
 
   state.isShuttingDown = true;
   console.log("[Main] Shutting down...");
+
+  // Stop Matter / integrations first
+  try {
+    await getIntegrationManager().stopAll();
+    console.log("[Main] Integrations stopped");
+  } catch (error) {
+    console.error("[Main] Error stopping integrations:", error);
+  }
 
   if (state.keepAlive) {
     state.keepAlive.stop();

--- a/packages/bridge/src/server/index.ts
+++ b/packages/bridge/src/server/index.ts
@@ -21,6 +21,7 @@ import {
 import { toApiError } from "./errors";
 import { deviceRoutes } from "./routes/devices";
 import { discoveryRoutes } from "./routes/discovery";
+import { matterRoutes, renderMatterPage } from "./routes/matter";
 import { setupRoutes } from "./routes/setup";
 import { timerRoutes } from "./routes/timers";
 import { initStaticFiles, isDevMode, staticFileMiddleware } from "./static";
@@ -317,6 +318,10 @@ export function createApp(config: ServerConfig = {}): Hono {
         "GET /api/devices/:id/keepalive",
         "PUT /api/devices/:id/keepalive",
         "GET /api/devices/:id/insight/diagnostics",
+        "GET /api/integrations/matter/status",
+        "POST /api/integrations/matter/enable",
+        "POST /api/integrations/matter/disable",
+        "GET /api/integrations/matter/pairing",
       ],
     });
   });
@@ -326,6 +331,7 @@ export function createApp(config: ServerConfig = {}): Hono {
   app.route("/api/devices/:id/timers", timerRoutes);
   app.route("/api/discover", discoveryRoutes);
   app.route("/api/setup", setupRoutes);
+  app.route("/api/integrations/matter", matterRoutes);
 
   // QR code page for phone setup
   app.get("/qr", async (c) => {
@@ -347,6 +353,12 @@ export function createApp(config: ServerConfig = {}): Hono {
   // Device setup page (for configuring new Wemo devices' WiFi)
   // Debug mode shows diagnostics panel (only in dev)
   app.get("/setup", createSetupRoute(DEFAULT_CONFIG.port, isDevMode()));
+
+  // Matter / Google Home commissioning page
+  app.get("/matter", async (c) => {
+    const html = await renderMatterPage();
+    return c.html(html);
+  });
 
   // API endpoint to save welcome preferences
   app.post("/api/welcome/complete", async (c) => {

--- a/packages/bridge/src/server/routes/__tests__/matter.test.ts
+++ b/packages/bridge/src/server/routes/__tests__/matter.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { parseId } from "../matter";
+
+describe("parseId", () => {
+  test("accepts hex strings", () => {
+    expect(parseId("0xFFF1", "vendorId")).toBe(65521);
+    expect(parseId("0x8001", "productId")).toBe(32769);
+    expect(parseId("  0xfff4  ", "vendorId")).toBe(65524);
+  });
+
+  test("accepts decimal strings and numbers", () => {
+    expect(parseId("65521", "vendorId")).toBe(65521);
+    expect(parseId(32769, "productId")).toBe(32769);
+  });
+
+  test("rejects values that are not integers", () => {
+    expect(() => parseId("nope", "vendorId")).toThrow();
+    expect(() => parseId(1.5, "productId")).toThrow();
+    expect(() => parseId(undefined, "vendorId")).toThrow();
+    expect(() => parseId(null, "productId")).toThrow();
+  });
+});

--- a/packages/bridge/src/server/routes/devices.ts
+++ b/packages/bridge/src/server/routes/devices.ts
@@ -1,29 +1,13 @@
 /**
  * Device CRUD API Routes
  *
- * Endpoints for managing saved devices.
+ * Thin wrappers over DeviceService.
  */
 
 import { Hono } from "hono";
-import { getDatabase } from "../../db";
-import { WemoDeviceClient } from "../../wemo/device";
-import { getDeviceByAddress } from "../../wemo/discovery";
-import { InsightDeviceClient, convertToPowerData, supportsInsight } from "../../wemo/insight";
-import {
-  isKeepAliveEnabled,
-  markManualOff,
-  markManualOn,
-  setKeepAliveEnabled,
-} from "../../wemo/keepalive";
-import { fetchRulesDb, parseAllRulesFromDb } from "../../wemo/rules";
-import { clearDeviceRules } from "../../wemo/scheduler";
-import type { SavedDevice, WemoDeviceType } from "../../wemo/types";
-import {
-  DeviceNotFoundError,
-  DeviceOfflineError,
-  InsightNotSupportedError,
-  ValidationError,
-} from "../errors";
+import { getDeviceService } from "../../device-service";
+import type { WemoDeviceType } from "../../wemo/types";
+import { ValidationError } from "../errors";
 
 /**
  * Device routes.
@@ -31,128 +15,21 @@ import {
 export const deviceRoutes = new Hono();
 
 /**
- * Helper to get a saved device by ID, throwing if not found.
- */
-function requireDevice(id: string): SavedDevice {
-  const db = getDatabase();
-  const device = db.getDeviceById(id);
-  if (!device) {
-    throw new DeviceNotFoundError(id);
-  }
-  return device;
-}
-
-/**
- * Helper to get a WemoDevice client from a SavedDevice.
- * Returns the client if device is reachable, throws otherwise.
- */
-async function getDeviceClient(device: SavedDevice): Promise<WemoDeviceClient> {
-  const wemoDevice = await getDeviceByAddress(device.host, device.port);
-  if (!wemoDevice) {
-    throw new DeviceOfflineError(device.id, "Device not reachable");
-  }
-  return new WemoDeviceClient(wemoDevice);
-}
-
-/**
- * Helper to get an Insight client from a SavedDevice.
- * Returns the client if device is reachable and supports Insight.
- */
-async function getInsightClient(device: SavedDevice): Promise<InsightDeviceClient> {
-  const wemoDevice = await getDeviceByAddress(device.host, device.port);
-  if (!wemoDevice) {
-    throw new DeviceOfflineError(device.id, "Device not reachable");
-  }
-  if (!supportsInsight(wemoDevice)) {
-    throw new InsightNotSupportedError(device.id);
-  }
-  return new InsightDeviceClient(wemoDevice);
-}
-
-/** Device state result type */
-type DeviceStateResult = {
-  isOnline: boolean;
-  state?: number;
-  error?: string;
-};
-
-/**
- * Wraps a promise with a timeout.
- */
-function withTimeout<T>(promise: Promise<T>, ms: number, fallback: T): Promise<T> {
-  return Promise.race([
-    promise,
-    new Promise<T>((resolve) => setTimeout(() => resolve(fallback), ms)),
-  ]);
-}
-
-/**
- * Helper to get device state safely with timeout.
- */
-async function getDeviceState(device: SavedDevice): Promise<DeviceStateResult> {
-  const offlineResult: DeviceStateResult = {
-    isOnline: false,
-    error: "Device not reachable (timeout)",
-  };
-
-  try {
-    // Wrap the entire operation in a 6-second timeout
-    return await withTimeout<DeviceStateResult>(
-      (async (): Promise<DeviceStateResult> => {
-        const client = await getDeviceClient(device);
-        const binaryState = await client.getBinaryState();
-        return { isOnline: true, state: binaryState };
-      })(),
-      6000,
-      offlineResult
-    );
-  } catch (error) {
-    return {
-      isOnline: false,
-      error: error instanceof Error ? error.message : "Unknown error",
-    };
-  }
-}
-
-/**
  * GET /api/devices
- *
- * Lists all saved devices with optional state polling.
- *
- * Query Parameters:
- * - includeState: Whether to poll current state (default: false, slower)
  */
 deviceRoutes.get("/", async (c) => {
   const includeState = c.req.query("includeState") === "true";
-  const db = getDatabase();
-  const devices = db.getAllDevices();
-
-  if (!includeState) {
-    return c.json({ devices });
-  }
-
-  // Poll state for each device (parallel)
-  const devicesWithState = await Promise.all(
-    devices.map(async (device) => {
-      const status = await getDeviceState(device);
-      return { ...device, ...status };
-    })
-  );
-
-  return c.json({ devices: devicesWithState });
+  const devices = await getDeviceService().listDevicesWithState(includeState);
+  return c.json({ devices });
 });
 
 /**
  * GET /api/devices/:id
- *
- * Gets a single device by ID with current state.
  */
 deviceRoutes.get("/:id", async (c) => {
-  const device = requireDevice(c.req.param("id"));
-
-  // Get current state
-  const status = await getDeviceState(device);
-
+  const svc = getDeviceService();
+  const device = svc.requireDevice(c.req.param("id"));
+  const status = await svc.getState(device.id);
   return c.json({
     device: { ...device, ...status },
   });
@@ -160,17 +37,6 @@ deviceRoutes.get("/:id", async (c) => {
 
 /**
  * POST /api/devices
- *
- * Adds or updates a device.
- *
- * Body:
- * {
- *   id?: string,      // Optional, will be generated if not provided
- *   name: string,
- *   host: string,
- *   port?: number,    // Default: 49153
- *   deviceType?: WemoDeviceType  // Default: "Switch"
- * }
  */
 deviceRoutes.post("/", async (c) => {
   const body = await c.req.json<{
@@ -181,130 +47,30 @@ deviceRoutes.post("/", async (c) => {
     deviceType?: WemoDeviceType;
   }>();
 
-  const missingFields: string[] = [];
-  if (!body.name) missingFields.push("name");
-  if (!body.host) missingFields.push("host");
-
-  if (missingFields.length > 0) {
-    throw new ValidationError(
-      `Missing required fields: ${missingFields.join(", ")}`,
-      missingFields
-    );
-  }
-
-  // Validate host is a valid IP address or hostname
-  const ipv4Regex = /^(\d{1,3}\.){3}\d{1,3}$/;
-  const hostnameRegex =
-    /^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*$/;
-
-  if (!ipv4Regex.test(body.host) && !hostnameRegex.test(body.host)) {
-    throw new ValidationError("Invalid host: must be a valid IP address or hostname", ["host"]);
-  }
-
-  // Additional IPv4 validation: each octet must be 0-255
-  if (ipv4Regex.test(body.host)) {
-    const octets = body.host.split(".").map(Number);
-    if (octets.some((octet) => octet < 0 || octet > 255)) {
-      throw new ValidationError("Invalid IP address: octets must be 0-255", ["host"]);
-    }
-  }
-
-  // Validate port is in valid range
-  if (body.port !== undefined) {
-    if (!Number.isInteger(body.port) || body.port < 1 || body.port > 65535) {
-      throw new ValidationError("Invalid port: must be an integer between 1 and 65535", ["port"]);
-    }
-  }
-
-  const db = getDatabase();
-  const now = new Date().toISOString();
-
-  // Try to discover the device to get its real ID
-  let deviceId = body.id;
-  let deviceType = body.deviceType ?? ("Switch" as WemoDeviceType);
-
-  if (!deviceId) {
-    try {
-      const discovered = await getDeviceByAddress(body.host, body.port ?? 49153);
-      if (discovered) {
-        deviceId = discovered.id;
-        deviceType = discovered.deviceType;
-      }
-    } catch {
-      // Ignore discovery errors, use provided or generated ID
-    }
-  }
-
-  // Generate ID if still not set
-  if (!deviceId) {
-    deviceId = `manual:${body.host}:${body.port ?? 49153}`;
-  }
-
-  const device: SavedDevice = {
-    id: deviceId,
-    name: body.name,
-    deviceType,
-    host: body.host,
-    port: body.port ?? 49153,
-    createdAt: now,
-    updatedAt: now,
-  };
-
-  db.saveDevice(device);
-
-  return c.json({ device, created: true }, 201);
+  const { device, created } = await getDeviceService().saveDevice(body);
+  return c.json({ device, created }, 201);
 });
 
 /**
  * PATCH /api/devices/:id
- *
- * Updates device properties.
- *
- * Body:
- * {
- *   name?: string,
- *   host?: string,
- *   port?: number
- * }
  */
 deviceRoutes.patch("/:id", async (c) => {
-  const existing = requireDevice(c.req.param("id"));
-
   const body = await c.req.json<{
     name?: string;
     host?: string;
     port?: number;
   }>();
 
-  const db = getDatabase();
-  const updated: SavedDevice = {
-    ...existing,
-    name: body.name ?? existing.name,
-    host: body.host ?? existing.host,
-    port: body.port ?? existing.port,
-    updatedAt: new Date().toISOString(),
-  };
-
-  db.saveDevice(updated);
-
-  return c.json({ device: updated });
+  const device = getDeviceService().updateDevice(c.req.param("id"), body);
+  return c.json({ device });
 });
 
 /**
  * DELETE /api/devices/:id
- *
- * Removes a device from the database.
  */
 deviceRoutes.delete("/:id", async (c) => {
   const id = c.req.param("id");
-
-  // Verify device exists first
-  requireDevice(id);
-
-  const db = getDatabase();
-  db.deleteDevice(id);
-  clearDeviceRules(id);
-
+  getDeviceService().deleteDevice(id);
   return c.json({ deleted: true, id });
 });
 
@@ -312,207 +78,62 @@ deviceRoutes.delete("/:id", async (c) => {
 // Device Control Endpoints
 // =============================================================================
 
-/**
- * GET /api/devices/:id/state
- *
- * Gets the current state of a device (lighter than full GET /:id).
- */
 deviceRoutes.get("/:id/state", async (c) => {
-  const device = requireDevice(c.req.param("id"));
-  const client = await getDeviceClient(device);
-  const state = await client.getBinaryState();
-
-  return c.json({
-    id: device.id,
-    state,
-    isOn: state === 1,
-    isStandby: state === 8,
-  });
+  const result = await getDeviceService().getBinaryState(c.req.param("id"));
+  return c.json(result);
 });
 
-/**
- * POST /api/devices/:id/on
- *
- * Turns the device on.
- */
 deviceRoutes.post("/:id/on", async (c) => {
-  const device = requireDevice(c.req.param("id"));
-  const client = await getDeviceClient(device);
-  await client.turnOn();
-  markManualOn(device.id);
-  const newState = await client.getBinaryState();
-
-  return c.json({
-    id: device.id,
-    action: "on",
-    state: newState,
-    isOn: newState === 1,
-  });
+  const result = await getDeviceService().setOn(c.req.param("id"), "api");
+  return c.json(result);
 });
 
-/**
- * POST /api/devices/:id/off
- *
- * Turns the device off.
- */
 deviceRoutes.post("/:id/off", async (c) => {
-  const device = requireDevice(c.req.param("id"));
-  const client = await getDeviceClient(device);
-  await client.turnOff();
-  markManualOff(device.id);
-  const newState = await client.getBinaryState();
-
-  return c.json({
-    id: device.id,
-    action: "off",
-    state: newState,
-    isOn: newState === 1,
-  });
+  const result = await getDeviceService().setOff(c.req.param("id"), "api");
+  return c.json(result);
 });
 
-/**
- * POST /api/devices/:id/toggle
- *
- * Toggles the device state.
- */
 deviceRoutes.post("/:id/toggle", async (c) => {
-  const device = requireDevice(c.req.param("id"));
-  const client = await getDeviceClient(device);
-  const { binaryState } = await client.toggle();
-
-  if (binaryState === 1) {
-    markManualOn(device.id);
-  } else {
-    markManualOff(device.id);
-  }
-
-  return c.json({
-    id: device.id,
-    action: "toggle",
-    state: binaryState,
-    isOn: binaryState === 1,
-  });
+  const result = await getDeviceService().toggle(c.req.param("id"), "api");
+  return c.json(result);
 });
 
-/**
- * GET /api/devices/:id/insight
- *
- * Gets power monitoring data for Insight devices.
- */
 deviceRoutes.get("/:id/insight", async (c) => {
-  const device = requireDevice(c.req.param("id"));
-  const client = await getInsightClient(device);
-  const powerData = await client.getPowerData();
-  const rawParams = await client.getInsightParams();
-
-  return c.json({
-    id: device.id,
-    power: powerData,
-    raw: rawParams,
-  });
+  const result = await getDeviceService().getInsight(c.req.param("id"));
+  return c.json(result);
 });
 
 deviceRoutes.get("/:id/threshold", async (c) => {
-  const device = requireDevice(c.req.param("id"));
-  const client = await getInsightClient(device);
-  const thresholdMilliwatts = await client.getPowerThreshold();
-  return c.json({
-    id: device.id,
-    thresholdWatts: thresholdMilliwatts / 1000,
-    thresholdMilliwatts,
-  });
+  const result = await getDeviceService().getThreshold(c.req.param("id"));
+  return c.json(result);
 });
 
 deviceRoutes.put("/:id/threshold", async (c) => {
-  const device = requireDevice(c.req.param("id"));
   const body = await c.req.json<{ watts?: unknown }>();
-
-  if (
-    typeof body.watts !== "number" ||
-    !Number.isFinite(body.watts) ||
-    body.watts < 0 ||
-    body.watts > 50
-  ) {
-    throw new ValidationError("Invalid watts: must be a number between 0 and 50", ["watts"]);
-  }
-
-  const client = await getInsightClient(device);
-  const milliwatts = Math.round(body.watts * 1000);
-  await client.setPowerThreshold(milliwatts);
-
-  return c.json({
-    id: device.id,
-    thresholdWatts: milliwatts / 1000,
-    thresholdMilliwatts: milliwatts,
-  });
+  const result = await getDeviceService().setThreshold(c.req.param("id"), body.watts as number);
+  return c.json(result);
 });
 
 deviceRoutes.post("/:id/threshold/reset", async (c) => {
-  const device = requireDevice(c.req.param("id"));
-  const client = await getInsightClient(device);
-  await client.resetPowerThreshold();
-  const confirmedMilliwatts = await client.getPowerThreshold();
-  return c.json({
-    id: device.id,
-    thresholdWatts: confirmedMilliwatts / 1000,
-    thresholdMilliwatts: confirmedMilliwatts,
-  });
+  const result = await getDeviceService().resetThreshold(c.req.param("id"));
+  return c.json(result);
 });
 
 // =============================================================================
-// Keep-Alive (LED / Low-Power Device Support)
+// Keep-Alive
 // =============================================================================
 
 deviceRoutes.get("/:id/keepalive", (c) => {
-  const device = requireDevice(c.req.param("id"));
-  return c.json({
-    id: device.id,
-    enabled: isKeepAliveEnabled(device.id),
-  });
+  return c.json(getDeviceService().getKeepAlive(c.req.param("id")));
 });
 
 deviceRoutes.put("/:id/keepalive", async (c) => {
-  const device = requireDevice(c.req.param("id"));
   const body = await c.req.json<{ enabled?: unknown }>();
-
   if (typeof body.enabled !== "boolean") {
     throw new ValidationError("Invalid enabled: must be a boolean", ["enabled"]);
   }
-
-  setKeepAliveEnabled(device.id, body.enabled);
-
-  if (device.deviceType === "Insight") {
-    try {
-      const client = await getInsightClient(device);
-      const autoThresholdWatts = body.enabled ? 0 : 8;
-      const displayThresholdMilliwatts = body.enabled ? 1 : 8000;
-      await Promise.all([
-        client.setAutoPowerThreshold(autoThresholdWatts),
-        client.setPowerThreshold(displayThresholdMilliwatts),
-      ]);
-
-      if (body.enabled) {
-        const state = await client.getBinaryState();
-        if (state === 0 || state === 8) {
-          markManualOff(device.id);
-        }
-      }
-
-      console.log(
-        `[KeepAlive] Set auto threshold to ${autoThresholdWatts}W, display threshold to ${displayThresholdMilliwatts}mW for "${device.name}"`
-      );
-    } catch (error) {
-      console.error(
-        `[KeepAlive] Failed to set power thresholds for "${device.name}":`,
-        error instanceof Error ? error.message : error
-      );
-    }
-  }
-
-  return c.json({
-    id: device.id,
-    enabled: body.enabled,
-  });
+  const result = await getDeviceService().setKeepAlive(c.req.param("id"), body.enabled);
+  return c.json(result);
 });
 
 // =============================================================================
@@ -520,42 +141,6 @@ deviceRoutes.put("/:id/keepalive", async (c) => {
 // =============================================================================
 
 deviceRoutes.get("/:id/insight/diagnostics", async (c) => {
-  const device = requireDevice(c.req.param("id"));
-  const client = await getInsightClient(device);
-
-  const [insightParams, thresholdMilliwatts, rulesResult] = await Promise.all([
-    client.getInsightParams(),
-    client.getPowerThreshold(),
-    fetchRulesDb(device.host, device.port),
-  ]);
-
-  const powerData = convertToPowerData(insightParams);
-  const allRules = parseAllRulesFromDb(rulesResult.dbBuffer);
-  const nonTimerRules = allRules.filter((r) => r.type !== "Timer");
-
-  const stateLabels: Record<number, string> = { 0: "off", 1: "on", 8: "standby" };
-
-  return c.json({
-    id: device.id,
-    insight: {
-      state: insightParams.state,
-      stateLabel: stateLabels[insightParams.state] ?? "unknown",
-      instantPowerMilliwatts: insightParams.instantPower,
-      instantPowerWatts: insightParams.instantPower / 1000,
-      reportedThresholdMilliwatts: insightParams.standbyThreshold,
-      reportedThresholdWatts: insightParams.standbyThreshold / 1000,
-      power: powerData,
-    },
-    threshold: {
-      milliwatts: thresholdMilliwatts,
-      watts: thresholdMilliwatts / 1000,
-    },
-    rules: {
-      dbVersion: rulesResult.version,
-      totalCount: allRules.length,
-      timerCount: allRules.length - nonTimerRules.length,
-      nonTimerCount: nonTimerRules.length,
-      all: allRules,
-    },
-  });
+  const result = await getDeviceService().getInsightDiagnostics(c.req.param("id"));
+  return c.json(result);
 });

--- a/packages/bridge/src/server/routes/matter.ts
+++ b/packages/bridge/src/server/routes/matter.ts
@@ -1,0 +1,166 @@
+/**
+ * Matter integration API routes.
+ */
+
+import { Hono } from "hono";
+import { getIntegrationManager } from "../../integrations";
+import { generateMatterPageHtml } from "../../integrations/matter/commissioning";
+import type { MatterDeviceKind } from "../../integrations/matter/mapper";
+import { ValidationError } from "../errors";
+
+export const matterRoutes = new Hono();
+
+function parseMatterKind(value: unknown): MatterDeviceKind | null {
+  if (value === null) {
+    return null;
+  }
+  if (value === "plug" || value === "light" || value === "skip") {
+    return value;
+  }
+  throw new ValidationError('kind must be "plug", "light", "skip", or null', ["kind"]);
+}
+
+/**
+ * Parses a vendor/product ID given as a number or hex string ("0xFFF1").
+ */
+export function parseId(value: unknown, field: string): number {
+  if (typeof value === "number" && Number.isInteger(value)) {
+    return value;
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    const parsed = trimmed.toLowerCase().startsWith("0x")
+      ? Number.parseInt(trimmed.slice(2), 16)
+      : Number.parseInt(trimmed, 10);
+    if (Number.isInteger(parsed)) {
+      return parsed;
+    }
+  }
+  throw new ValidationError(`Invalid ${field}: must be a number or hex string like 0xFFF1`, [
+    field,
+  ]);
+}
+
+/**
+ * GET /api/integrations/matter/status
+ */
+matterRoutes.get("/status", (c) => {
+  const mgr = getIntegrationManager();
+  return c.json({
+    enabled: mgr.isMatterEnabled(),
+    ...mgr.getMatterStatus(),
+  });
+});
+
+/**
+ * POST /api/integrations/matter/enable
+ */
+matterRoutes.post("/enable", async (c) => {
+  const status = await getIntegrationManager().enableMatter();
+  return c.json({ enabled: true, ...status });
+});
+
+/**
+ * POST /api/integrations/matter/disable
+ */
+matterRoutes.post("/disable", async (c) => {
+  const status = await getIntegrationManager().disableMatter();
+  return c.json({ enabled: false, ...status });
+});
+
+/**
+ * POST /api/integrations/matter/reset
+ *
+ * Clears commissioned fabrics so the bridge can be paired again.
+ */
+matterRoutes.post("/reset", async (c) => {
+  const mgr = getIntegrationManager();
+  const status = await mgr.resetMatterCommissioning();
+  return c.json({ reset: true, enabled: mgr.isMatterEnabled(), ...status });
+});
+
+/**
+ * PUT /api/integrations/matter/identity
+ *
+ * Sets the advertised vendor/product IDs. These must match the Matter
+ * integration registered in the Google Home Developer Console.
+ */
+matterRoutes.put("/identity", async (c) => {
+  const body = await c.req.json<{ vendorId?: unknown; productId?: unknown }>();
+  const vendorId = parseId(body.vendorId, "vendorId");
+  const productId = parseId(body.productId, "productId");
+
+  const mgr = getIntegrationManager();
+  try {
+    const status = await mgr.setMatterIdentity(vendorId, productId);
+    return c.json({ enabled: mgr.isMatterEnabled(), ...status });
+  } catch (error) {
+    throw new ValidationError(error instanceof Error ? error.message : "Invalid Matter identity", [
+      "vendorId",
+      "productId",
+    ]);
+  }
+});
+
+/**
+ * PUT /api/integrations/matter/devices/:id/kind
+ *
+ * Sets or clears a per-device Matter kind override.
+ * Body: { "kind": "plug" | "light" | "skip" | null }
+ */
+matterRoutes.put("/devices/:id/kind", async (c) => {
+  const id = c.req.param("id");
+  const body = await c.req.json<{ kind?: unknown }>();
+  const kind = parseMatterKind(body.kind);
+
+  const mgr = getIntegrationManager();
+  try {
+    const status = await mgr.setDeviceKind(id, kind);
+    return c.json({ enabled: mgr.isMatterEnabled(), ...status });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to set Matter kind";
+    if (message.startsWith("Device not found")) {
+      return c.json({ error: true, code: "NOT_FOUND", message }, 404);
+    }
+    throw new ValidationError(message, ["kind"]);
+  }
+});
+
+/**
+ * GET /api/integrations/matter/pairing
+ */
+matterRoutes.get("/pairing", (c) => {
+  const mgr = getIntegrationManager();
+  const status = mgr.getMatterStatus();
+  if (!mgr.isMatterEnabled() || !status.pairing) {
+    return c.json(
+      {
+        error: true,
+        code: "MATTER_NOT_RUNNING",
+        message: "Matter bridge is not enabled or not running",
+      },
+      503
+    );
+  }
+  return c.json({
+    enabled: true,
+    ...status.pairing,
+    deviceCount: status.deviceCount,
+  });
+});
+
+/**
+ * Serves the Matter commissioning HTML page (used from server/index).
+ */
+export async function renderMatterPage(): Promise<string> {
+  const mgr = getIntegrationManager();
+  const status = mgr.getMatterStatus();
+  return generateMatterPageHtml({
+    enabled: mgr.isMatterEnabled(),
+    running: status.running,
+    pairing: status.pairing,
+    error: status.error,
+    deviceCount: status.deviceCount,
+    identity: status.identity,
+  });
+}

--- a/packages/bridge/src/tray/menu.ts
+++ b/packages/bridge/src/tray/menu.ts
@@ -15,6 +15,8 @@ export const MenuItemIds = {
   OPEN_BROWSER: "open-browser",
   SHOW_QR: "show-qr",
   SETUP_DEVICE: "setup-device",
+  LINK_GOOGLE_HOME: "link-google-home",
+  MATTER_TOGGLE: "matter-toggle",
   DISCOVER: "discover",
   START_ON_LOGIN: "start-on-login",
   QUIT: "quit",
@@ -27,6 +29,8 @@ export interface MenuHandlers {
   onOpenBrowser?: () => void;
   onShowQR?: () => void;
   onSetupDevice?: () => void;
+  onLinkGoogleHome?: () => void;
+  onMatterToggle?: (enabled: boolean) => void | Promise<void>;
   onDiscover?: () => Promise<void>;
   onStartOnLoginToggle?: (enabled: boolean) => void;
   onQuit?: () => void;
@@ -35,7 +39,7 @@ export interface MenuHandlers {
 /**
  * Creates the default menu items.
  */
-export function createMenuItems(startOnLogin = false): MenuItem[] {
+export function createMenuItems(startOnLogin = false, matterEnabled = false): MenuItem[] {
   return [
     {
       id: MenuItemIds.OPEN_BROWSER,
@@ -51,6 +55,17 @@ export function createMenuItems(startOnLogin = false): MenuItem[] {
       id: MenuItemIds.SETUP_DEVICE,
       title: "Setup New Device",
       tooltip: "Configure a new WeMo device's WiFi",
+    },
+    {
+      id: MenuItemIds.LINK_GOOGLE_HOME,
+      title: "Link to Google Home",
+      tooltip: "Show Matter pairing QR for Google Home",
+    },
+    {
+      id: MenuItemIds.MATTER_TOGGLE,
+      title: "Matter Bridge",
+      tooltip: "Expose WeMo devices to Google Home via Matter",
+      checked: matterEnabled,
     },
     {
       id: MenuItemIds.DISCOVER,
@@ -97,7 +112,8 @@ export function openInBrowser(url: string): void {
 export function createMenuClickHandler(
   handlers: MenuHandlers,
   getStartOnLogin: () => boolean,
-  setStartOnLogin: (value: boolean) => void
+  setStartOnLogin: (value: boolean) => void,
+  getMatterEnabled: () => boolean = () => false
 ): MenuClickHandler {
   return async (itemId: string) => {
     switch (itemId) {
@@ -112,6 +128,16 @@ export function createMenuClickHandler(
       case MenuItemIds.SETUP_DEVICE:
         handlers.onSetupDevice?.();
         break;
+
+      case MenuItemIds.LINK_GOOGLE_HOME:
+        handlers.onLinkGoogleHome?.();
+        break;
+
+      case MenuItemIds.MATTER_TOGGLE: {
+        const newValue = !getMatterEnabled();
+        await handlers.onMatterToggle?.(newValue);
+        break;
+      }
 
       case MenuItemIds.DISCOVER:
         await handlers.onDiscover?.();

--- a/packages/web/css/style.css
+++ b/packages/web/css/style.css
@@ -1721,6 +1721,385 @@ body {
 }
 
 /* ============================================
+   Matter / Google Home
+   ============================================ */
+.settings-full-btn {
+  width: 100%;
+  justify-content: flex-start;
+  gap: var(--spacing-sm);
+}
+
+.settings-badge {
+  margin-left: auto;
+  padding: 2px var(--spacing-sm);
+  border-radius: var(--radius-full);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  background-color: var(--color-bg-hover);
+  color: var(--color-text-muted);
+}
+
+.settings-badge-on {
+  background-color: rgba(74, 222, 128, 0.15);
+  color: var(--color-on);
+}
+
+.settings-badge-warn {
+  background-color: rgba(245, 158, 11, 0.15);
+  color: var(--color-warning);
+}
+
+.settings-badge-error {
+  background-color: rgba(239, 68, 68, 0.15);
+  color: var(--color-error);
+}
+
+.matter-modal-content {
+  max-width: 460px;
+}
+
+.matter-hero {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md);
+  padding: var(--spacing-md);
+  background-color: var(--color-surface);
+  border-radius: var(--radius-lg);
+  margin-bottom: var(--spacing-md);
+}
+
+.matter-hero-text {
+  flex: 1;
+  min-width: 0;
+}
+
+.matter-state {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  font-weight: var(--font-weight-semibold);
+}
+
+.matter-state-on {
+  color: var(--color-on);
+}
+
+.matter-state-warn {
+  color: var(--color-warning);
+}
+
+.matter-state-off {
+  color: var(--color-text-muted);
+}
+
+.matter-hero-sub {
+  margin-top: var(--spacing-xs);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
+/* Toggle switch */
+.matter-switch {
+  position: relative;
+  flex-shrink: 0;
+  cursor: pointer;
+}
+
+.matter-switch input {
+  position: absolute;
+  opacity: 0;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  cursor: pointer;
+}
+
+.matter-switch-track {
+  display: block;
+  width: 52px;
+  height: 30px;
+  padding: 3px;
+  border-radius: var(--radius-full);
+  background-color: var(--color-bg-hover);
+  transition: background-color var(--transition-normal);
+}
+
+.matter-switch-thumb {
+  display: block;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background-color: #ffffff;
+  box-shadow: var(--shadow-sm);
+  transition: transform var(--transition-normal);
+}
+
+.matter-switch input:checked + .matter-switch-track {
+  background-color: var(--color-primary);
+}
+
+.matter-switch input:checked + .matter-switch-track .matter-switch-thumb {
+  transform: translateX(22px);
+}
+
+.matter-switch input:disabled + .matter-switch-track {
+  opacity: 0.5;
+}
+
+.matter-switch input:focus-visible + .matter-switch-track {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+/* Alerts */
+.matter-alert {
+  padding: var(--spacing-md);
+  border-radius: var(--radius-lg);
+  border-left: 3px solid var(--color-border);
+  background-color: var(--color-surface);
+  margin-bottom: var(--spacing-md);
+  font-size: var(--font-size-sm);
+}
+
+.matter-alert > strong {
+  display: block;
+  margin-bottom: var(--spacing-xs);
+}
+
+.matter-alert p {
+  color: var(--color-text-muted);
+  line-height: 1.5;
+}
+
+.matter-alert a {
+  color: var(--color-info);
+}
+
+.matter-alert-info {
+  border-left-color: var(--color-info);
+}
+
+.matter-alert-success {
+  border-left-color: var(--color-on);
+}
+
+.matter-alert-warn {
+  border-left-color: var(--color-warning);
+}
+
+.matter-alert-error {
+  border-left-color: var(--color-error);
+}
+
+.matter-alert-error strong {
+  color: var(--color-error);
+}
+
+.matter-steps {
+  margin: var(--spacing-sm) 0 0 var(--spacing-md);
+  padding-left: var(--spacing-md);
+  color: var(--color-text-muted);
+  line-height: 1.6;
+}
+
+.matter-steps li {
+  margin-bottom: var(--spacing-xs);
+}
+
+.matter-steps code,
+.matter-details code {
+  font-family: monospace;
+  padding: 1px 4px;
+  border-radius: var(--radius-sm);
+  background-color: var(--color-bg-hover);
+  color: var(--color-text);
+}
+
+.matter-muted {
+  margin-top: var(--spacing-sm);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-dim);
+  line-height: 1.5;
+}
+
+/* Pairing block */
+.matter-pair {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: var(--spacing-md);
+  background-color: var(--color-surface);
+  border-radius: var(--radius-lg);
+  margin-bottom: var(--spacing-md);
+}
+
+.matter-pair-intro {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  margin-bottom: var(--spacing-md);
+  line-height: 1.5;
+}
+
+.matter-qr {
+  width: 200px;
+  height: 200px;
+}
+
+.matter-code {
+  font-family: monospace;
+  font-size: var(--font-size-lg);
+  letter-spacing: 0.08em;
+  padding: var(--spacing-sm) var(--spacing-md);
+  background-color: var(--color-bg);
+  border-radius: var(--radius-md);
+  word-break: break-all;
+}
+
+.matter-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-sm);
+  margin-top: var(--spacing-md);
+}
+
+/* Advanced */
+.matter-details {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: var(--spacing-sm) var(--spacing-md);
+}
+
+.matter-details summary {
+  cursor: pointer;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-muted);
+  padding: var(--spacing-xs) 0;
+}
+
+.matter-details-body {
+  padding-top: var(--spacing-sm);
+}
+
+.matter-id-row {
+  display: flex;
+  gap: var(--spacing-sm);
+  margin-top: var(--spacing-sm);
+}
+
+.matter-field {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+}
+
+.matter-field input {
+  padding: var(--spacing-sm);
+  font-family: monospace;
+  font-size: var(--font-size-sm);
+  color: var(--color-text);
+  background-color: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+}
+
+.matter-field input:focus {
+  outline: none;
+  border-color: var(--color-primary);
+}
+
+.matter-devices {
+  margin-bottom: var(--spacing-md);
+  padding: var(--spacing-md);
+  background-color: var(--color-surface);
+  border-radius: var(--radius-lg);
+}
+
+.matter-devices-title {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  margin-bottom: var(--spacing-xs);
+}
+
+.matter-device-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-sm) 0;
+  border-top: 1px solid var(--color-border);
+}
+
+.matter-device-row:first-of-type {
+  border-top: none;
+  margin-top: var(--spacing-sm);
+}
+
+.matter-device-info {
+  flex: 1;
+  min-width: 120px;
+}
+
+.matter-device-name {
+  font-weight: var(--font-weight-medium);
+  font-size: var(--font-size-sm);
+}
+
+.matter-device-meta {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-dim);
+}
+
+.matter-kind-badge {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  padding: 2px var(--spacing-sm);
+  border-radius: var(--radius-full);
+  background-color: var(--color-bg-hover);
+  color: var(--color-text-muted);
+}
+
+.matter-kind-plug {
+  background-color: rgba(74, 222, 128, 0.15);
+  color: var(--color-on);
+}
+
+.matter-kind-light {
+  background-color: rgba(59, 130, 246, 0.15);
+  color: var(--color-info);
+}
+
+.matter-kind-skip {
+  background-color: rgba(107, 114, 128, 0.2);
+  color: var(--color-text-dim);
+}
+
+.matter-kind-select select,
+.matter-kind-override-row select {
+  width: 100%;
+  padding: var(--spacing-xs) var(--spacing-sm);
+  font-size: var(--font-size-sm);
+  color: var(--color-text);
+  background-color: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+}
+
+.matter-kind-overrides {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.matter-kind-override-row {
+  width: 100%;
+}
+
+/* ============================================
    Setup Mode UI
    ============================================ */
 .setup-mode {

--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -317,6 +317,21 @@
           <p class="settings-install-hint">Install the app or share with another device</p>
         </div>
         
+        <!-- Smart home integrations -->
+        <div class="settings-group">
+          <label class="settings-label">Smart Home</label>
+          <button class="btn settings-action-btn settings-full-btn" id="settings-matter-btn">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M3 10.5 12 3l9 7.5"/>
+              <path d="M5 9.5V20a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V9.5"/>
+              <path d="M10 21v-6h4v6"/>
+            </svg>
+            Google Home &amp; Matter
+            <span class="settings-badge" id="settings-matter-badge">Off</span>
+          </button>
+          <p class="settings-install-hint">Control your WeMo devices with Google Home, Apple Home, or Alexa</p>
+        </div>
+        
         <!-- Divider -->
         <hr class="settings-divider">
         
@@ -446,6 +461,28 @@
           </div>
         </div>
         <p class="qr-modal-url" id="qr-modal-url"></p>
+      </div>
+    </div>
+  </div>
+
+  <!-- Matter / Google Home Modal -->
+  <div id="matter-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="matter-modal-title">
+    <div class="modal-backdrop"></div>
+    <div class="modal-content matter-modal-content">
+      <div class="modal-header">
+        <h2 class="modal-title" id="matter-modal-title">Google Home &amp; Matter</h2>
+        <button class="btn btn-icon modal-close" id="matter-modal-close" aria-label="Close">
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M18 6L6 18"/>
+            <path d="M6 6l12 12"/>
+          </svg>
+        </button>
+      </div>
+      <div class="modal-body" id="matter-content">
+        <div class="loading" role="status">
+          <div class="spinner" aria-hidden="true"></div>
+          <p>Loading Matter status...</p>
+        </div>
       </div>
     </div>
   </div>

--- a/packages/web/js/api.js
+++ b/packages/web/js/api.js
@@ -317,6 +317,79 @@ export const api = {
       body: JSON.stringify({ enabled }),
     });
   },
+
+  /**
+   * Get Matter bridge status (Google Home / Apple Home / Alexa).
+   * @returns {Promise<Object>} Status including pairing codes and identity
+   */
+  async getMatterStatus() {
+    return request("/integrations/matter/status");
+  },
+
+  /**
+   * Enable the Matter bridge. Starting the Matter stack can take a few seconds.
+   * @returns {Promise<Object>} Updated status
+   */
+  async enableMatter() {
+    return request("/integrations/matter/enable", {
+      method: "POST",
+      body: "{}",
+      timeout: 30000,
+    });
+  },
+
+  /**
+   * Disable the Matter bridge.
+   * @returns {Promise<Object>} Updated status
+   */
+  async disableMatter() {
+    return request("/integrations/matter/disable", {
+      method: "POST",
+      body: "{}",
+      timeout: 30000,
+    });
+  },
+
+  /**
+   * Clear commissioned Matter fabrics so the bridge can be paired again.
+   * @returns {Promise<Object>} Updated status
+   */
+  async resetMatterPairing() {
+    return request("/integrations/matter/reset", {
+      method: "POST",
+      body: "{}",
+      timeout: 30000,
+    });
+  },
+
+  /**
+   * Set the advertised Matter vendor/product IDs.
+   * Must match the integration registered in the Google Home Developer Console.
+   * @param {string|number} vendorId - e.g. "0xFFF1"
+   * @param {string|number} productId - e.g. "0x8001"
+   * @returns {Promise<Object>} Updated status
+   */
+  async setMatterIdentity(vendorId, productId) {
+    return request("/integrations/matter/identity", {
+      method: "PUT",
+      body: JSON.stringify({ vendorId, productId }),
+      timeout: 30000,
+    });
+  },
+
+  /**
+   * Override or clear the Matter kind for a saved device.
+   * @param {string} id - Device ID
+   * @param {"plug"|"light"|"skip"|null} kind - Matter kind, or null to clear override
+   * @returns {Promise<Object>} Updated status
+   */
+  async setMatterDeviceKind(id, kind) {
+    return request(`/integrations/matter/devices/${encodeURIComponent(id)}/kind`, {
+      method: "PUT",
+      body: JSON.stringify({ kind }),
+      timeout: 30000,
+    });
+  },
 };
 
 export default api;

--- a/packages/web/js/app.js
+++ b/packages/web/js/app.js
@@ -82,6 +82,11 @@ const $qrModalUrl = document.getElementById("qr-modal-url");
 const $setupInstructionsModal = document.getElementById("setup-instructions-modal");
 const $setupInstructionsClose = document.getElementById("setup-instructions-close");
 const $setupInstructionsCancel = document.getElementById("setup-instructions-cancel");
+const $settingsMatterBtn = document.getElementById("settings-matter-btn");
+const $settingsMatterBadge = document.getElementById("settings-matter-badge");
+const $matterModal = document.getElementById("matter-modal");
+const $matterModalClose = document.getElementById("matter-modal-close");
+const $matterContent = document.getElementById("matter-content");
 
 // ============================================
 // Service Worker Registration
@@ -1525,12 +1530,16 @@ async function loadDevices() {
 // ============================================
 
 /**
- * Escapes HTML special characters.
+ * Escapes HTML special characters. Quotes are escaped too so the result is
+ * safe inside attribute values.
  */
 function escapeHtml(text) {
-  const div = document.createElement("div");
-  div.textContent = text;
-  return div.innerHTML;
+  return String(text ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
 }
 
 // ============================================
@@ -1661,6 +1670,7 @@ function applyTheme(theme) {
 function openSettingsModal() {
   updateSettingsUI();
   updateBridgeStatus();
+  refreshMatterBadge();
   $settingsModal.classList.remove("hidden");
 }
 
@@ -1877,6 +1887,9 @@ function setupEscapeKeyHandler() {
       if ($setupInstructionsModal && !$setupInstructionsModal.classList.contains("hidden")) {
         hideSetupInstructionsModal();
       }
+      if ($matterModal && !$matterModal.classList.contains("hidden")) {
+        closeMatterModal();
+      }
       const $timerFormModal = document.getElementById("timer-form-modal");
       if ($timerFormModal) {
         $timerFormModal.remove();
@@ -1943,6 +1956,16 @@ function setupSettingsListeners() {
     $qrModalClose.addEventListener("click", hideQRModal);
   }
   $qrModal?.querySelector(".modal-backdrop")?.addEventListener("click", hideQRModal);
+
+  // Matter / Google Home
+  if ($settingsMatterBtn) {
+    $settingsMatterBtn.addEventListener("click", () => {
+      closeSettingsModal();
+      openMatterModal();
+    });
+  }
+  $matterModalClose?.addEventListener("click", closeMatterModal);
+  $matterModal?.querySelector(".modal-backdrop")?.addEventListener("click", closeMatterModal);
 }
 
 // ============================================
@@ -2024,6 +2047,510 @@ async function generateQRCode() {
       </div>
     `;
   }
+}
+
+// ============================================
+// Matter / Google Home
+// ============================================
+
+const matterState = {
+  status: null,
+  busy: false,
+};
+
+const GOOGLE_CONSOLE_URL = "https://console.home.google.com/projects";
+
+/**
+ * Updates the "Off / On / Linked" badge on the settings button.
+ */
+async function refreshMatterBadge() {
+  if (!$settingsMatterBadge) return;
+
+  try {
+    const status = await api.getMatterStatus();
+    matterState.status = status;
+
+    let label = "Off";
+    let modifier = "settings-badge-off";
+    if (status.enabled && status.commissioned) {
+      label = "Linked";
+      modifier = "settings-badge-on";
+    } else if (status.enabled && status.running) {
+      label = "Ready to pair";
+      modifier = "settings-badge-warn";
+    } else if (status.enabled) {
+      label = "Error";
+      modifier = "settings-badge-error";
+    }
+
+    $settingsMatterBadge.textContent = label;
+    $settingsMatterBadge.className = `settings-badge ${modifier}`;
+  } catch (error) {
+    log("[App] Could not read Matter status:", error);
+    $settingsMatterBadge.textContent = "—";
+    $settingsMatterBadge.className = "settings-badge settings-badge-off";
+  }
+}
+
+/**
+ * Opens the Matter / Google Home modal.
+ */
+function openMatterModal() {
+  if (!$matterModal) return;
+  $matterModal.classList.remove("hidden");
+  trapFocus($matterModal);
+  loadMatterStatus();
+}
+
+function closeMatterModal() {
+  $matterModal?.classList.add("hidden");
+  refreshMatterBadge();
+}
+
+/**
+ * Fetches Matter status and renders the panel.
+ */
+async function loadMatterStatus() {
+  if (!$matterContent) return;
+
+  $matterContent.innerHTML = `
+    <div class="loading" role="status">
+      <div class="spinner" aria-hidden="true"></div>
+      <p>Loading Matter status...</p>
+    </div>
+  `;
+
+  try {
+    matterState.status = await api.getMatterStatus();
+    renderMatterPanel();
+  } catch (error) {
+    $matterContent.innerHTML = `
+      <div class="matter-alert matter-alert-error">
+        <strong>Couldn't reach the bridge.</strong>
+        <p>${escapeHtml(error.message)}</p>
+      </div>
+    `;
+  }
+}
+
+/**
+ * Renders the Matter panel from the current status.
+ */
+function renderMatterPanel() {
+  if (!$matterContent) return;
+
+  const status = matterState.status ?? {};
+  const pairing = status.pairing;
+  const identity = status.identity ?? {};
+  const busy = matterState.busy;
+
+  const stateLabel = !status.enabled
+    ? "Disabled"
+    : status.commissioned
+      ? "Linked to a controller"
+      : status.running
+        ? "Running — ready to pair"
+        : "Enabled, but not running";
+  const stateClass = !status.enabled
+    ? "matter-state-off"
+    : status.running
+      ? "matter-state-on"
+      : "matter-state-warn";
+
+  const deviceSummary = status.enabled
+    ? `${status.deviceCount ?? 0} device${status.deviceCount === 1 ? "" : "s"} exposed${
+        status.skippedCount ? ` · ${status.skippedCount} unsupported` : ""
+      }`
+    : "Turn on to expose your WeMo devices";
+
+  $matterContent.innerHTML = `
+    <div class="matter-hero">
+      <div class="matter-hero-text">
+        <div class="matter-state ${stateClass}">
+          <span class="status-dot ${status.running ? "status-dot-connected" : "status-dot-disconnected"}"></span>
+          ${escapeHtml(stateLabel)}
+        </div>
+        <p class="matter-hero-sub">${escapeHtml(deviceSummary)}</p>
+      </div>
+      <label class="matter-switch">
+        <input type="checkbox" id="matter-toggle" ${status.enabled ? "checked" : ""} ${busy ? "disabled" : ""}>
+        <span class="matter-switch-track"><span class="matter-switch-thumb"></span></span>
+      </label>
+    </div>
+
+    ${
+      status.error
+        ? `<div class="matter-alert matter-alert-error">
+             <strong>Matter failed to start</strong>
+             <p>${escapeHtml(status.error)}</p>
+           </div>`
+        : ""
+    }
+
+    ${renderMatterPairingSection(status, pairing)}
+
+    ${renderMatterDevicesSection(status, busy)}
+
+    <div class="matter-alert matter-alert-info">
+      <strong>Google Home needs a one-time registration</strong>
+      <p>
+        Google only pairs uncertified Matter devices that are registered in the
+        Google Home Developer Console. If Google Home finds Open Wemo but stops with
+        “Couldn't find device”, this is why.
+      </p>
+      <ol class="matter-steps">
+        <li>Open the <a href="${GOOGLE_CONSOLE_URL}" target="_blank" rel="noopener">Google Home Developer Console</a> and create a project.</li>
+        <li>Add a <strong>Matter</strong> integration with Vendor ID <code>${escapeHtml(identity.vendorIdHex ?? "0xFFF1")}</code> and Product ID <code>${escapeHtml(identity.productIdHex ?? "0x8001")}</code>.</li>
+        <li>Use the same Google account in the Google Home app, then scan the code above.</li>
+      </ol>
+      <p class="matter-muted">Apple Home and Alexa pair without this — they only show an “uncertified accessory” warning.</p>
+    </div>
+
+    <details class="matter-details">
+      <summary>Advanced</summary>
+      <div class="matter-details-body">
+        <p class="matter-muted">
+          Change these only to match a different integration in the Google Home Developer Console.
+          Saving clears the existing pairing.
+        </p>
+        <div class="matter-id-row">
+          <label class="matter-field">
+            <span>Vendor ID</span>
+            <input type="text" id="matter-vendor-id" value="${escapeHtml(identity.vendorIdHex ?? "0xFFF1")}" spellcheck="false">
+          </label>
+          <label class="matter-field">
+            <span>Product ID</span>
+            <input type="text" id="matter-product-id" value="${escapeHtml(identity.productIdHex ?? "0x8001")}" spellcheck="false">
+          </label>
+        </div>
+        <div class="matter-actions">
+          <button class="btn" id="matter-save-identity" ${busy ? "disabled" : ""}>Save IDs</button>
+          <button class="btn btn-danger" id="matter-reset" ${busy ? "disabled" : ""}>Reset pairing</button>
+        </div>
+        <p class="matter-muted">
+          Bridge listens on UDP port ${escapeHtml(status.port ?? 5540)}. Phone and computer must be on the
+          same network with client isolation off. Nest Matter hub required for Google Home control.
+          On/off is on the Google Home <em>tile</em>, not the device settings page.
+        </p>
+        ${renderMatterKindOverrides(status, busy)}
+      </div>
+    </details>
+  `;
+
+  attachMatterListeners();
+}
+
+/**
+ * Human label for a Matter kind.
+ */
+function matterKindLabel(kind) {
+  switch (kind) {
+    case "plug":
+      return "Plug (on/off)";
+    case "light":
+      return "Light (on/off)";
+    case "skip":
+      return "Skipped";
+    default:
+      return String(kind ?? "—");
+  }
+}
+
+/**
+ * Lists each WeMo device with its auto Matter kind.
+ */
+function renderMatterDevicesSection(status, busy) {
+  const devices = Array.isArray(status.devices) ? status.devices : [];
+  if (devices.length === 0) {
+    return `
+      <div class="matter-alert matter-alert-muted">
+        <p>No saved WeMo devices yet. Add devices in Open Wemo, then they appear here automatically as Plug or Light.</p>
+      </div>
+    `;
+  }
+
+  const rows = devices
+    .map((device) => {
+      const needsPicker = device.wemoType === "Unknown" || device.source === "override";
+      const badgeClass =
+        device.matterKind === "skip"
+          ? "matter-kind-skip"
+          : device.matterKind === "light"
+            ? "matter-kind-light"
+            : "matter-kind-plug";
+      const sourceNote =
+        device.source === "override"
+          ? " · override"
+          : device.wemoType === "Unknown"
+            ? " · default"
+            : "";
+
+      return `
+        <div class="matter-device-row" data-device-id="${escapeHtml(device.id)}">
+          <div class="matter-device-info">
+            <div class="matter-device-name">${escapeHtml(device.name)}</div>
+            <div class="matter-device-meta">
+              WeMo ${escapeHtml(device.wemoType)}
+              ${device.exposed ? " · exposed" : ""}
+            </div>
+          </div>
+          <span class="matter-kind-badge ${badgeClass}">
+            ${escapeHtml(matterKindLabel(device.matterKind))}${escapeHtml(sourceNote)}
+          </span>
+          ${
+            needsPicker
+              ? `<label class="matter-kind-select">
+                   <span class="sr-only">Matter type for ${escapeHtml(device.name)}</span>
+                   <select data-matter-kind="${escapeHtml(device.id)}" ${busy ? "disabled" : ""}>
+                     <option value="plug" ${device.matterKind === "plug" ? "selected" : ""}>Plug (on/off)</option>
+                     <option value="light" ${device.matterKind === "light" ? "selected" : ""}>Light (on/off)</option>
+                     <option value="skip" ${device.matterKind === "skip" ? "selected" : ""}>Skip</option>
+                     ${
+                       device.source === "override"
+                         ? `<option value="__auto__">Use automatic</option>`
+                         : ""
+                     }
+                   </select>
+                 </label>`
+              : ""
+          }
+        </div>
+      `;
+    })
+    .join("");
+
+  return `
+    <div class="matter-devices">
+      <div class="matter-devices-title">Devices</div>
+      <p class="matter-muted">Types are detected automatically from each WeMo. Google Home shows on/off on the home tile (not the settings page).</p>
+      ${rows}
+    </div>
+  `;
+}
+
+/**
+ * Advanced: change Matter kind for any device.
+ */
+function renderMatterKindOverrides(status, busy) {
+  const devices = Array.isArray(status.devices) ? status.devices : [];
+  if (devices.length === 0) return "";
+
+  const rows = devices
+    .map((device) => {
+      const selected = device.source === "override" ? device.matterKind : "__auto__";
+      return `
+        <label class="matter-field matter-kind-override-row">
+          <span>${escapeHtml(device.name)}</span>
+          <select data-matter-kind-advanced="${escapeHtml(device.id)}" ${busy ? "disabled" : ""}>
+            <option value="__auto__" ${selected === "__auto__" ? "selected" : ""}>
+              Automatic (${escapeHtml(matterKindLabel(device.autoKind))})
+            </option>
+            <option value="plug" ${selected === "plug" ? "selected" : ""}>Plug (on/off)</option>
+            <option value="light" ${selected === "light" ? "selected" : ""}>Light (on/off)</option>
+            <option value="skip" ${selected === "skip" ? "selected" : ""}>Skip</option>
+          </select>
+        </label>
+      `;
+    })
+    .join("");
+
+  return `
+    <div class="matter-kind-overrides">
+      <p class="matter-muted" style="margin-top: var(--spacing-md)">
+        Change type only if Google Home has no on/off control after pairing. You may need to remove the device
+        from Google Home and pair again.
+      </p>
+      ${rows}
+    </div>
+  `;
+}
+
+/**
+ * Renders the QR / setup code block.
+ */
+function renderMatterPairingSection(status, pairing) {
+  if (!status.enabled) {
+    return `
+      <div class="matter-alert matter-alert-muted">
+        <p>Turn on the switch above to advertise Open Wemo as a Matter bridge on your network.</p>
+      </div>
+    `;
+  }
+
+  if (status.commissioned) {
+    return `
+      <div class="matter-alert matter-alert-success">
+        <strong>Already paired</strong>
+        <p>
+          Open Wemo is linked to a Matter controller. Your devices should be in the Google Home app.
+          To pair with a different home, remove “Open Wemo” there and use <em>Reset pairing</em> below.
+        </p>
+      </div>
+    `;
+  }
+
+  if (!pairing) {
+    return `
+      <div class="matter-alert matter-alert-warn">
+        <p>Waiting for the Matter bridge to come online. This usually takes a few seconds.</p>
+        <div class="matter-actions">
+          <button class="btn" id="matter-refresh">Refresh</button>
+        </div>
+      </div>
+    `;
+  }
+
+  return `
+    <div class="matter-pair">
+      <p class="matter-pair-intro">
+        In the Google Home app: <strong>Devices → Add → Matter-enabled device</strong>, then scan this code.
+      </p>
+      <div class="qr-code-container matter-qr" id="matter-qr"></div>
+      <p class="matter-muted">Or enter the setup code manually</p>
+      <div class="matter-code" id="matter-code">${escapeHtml(pairing.manualPairingCode)}</div>
+      <div class="matter-actions">
+        <button class="btn" id="matter-copy-code">Copy setup code</button>
+        <button class="btn" id="matter-refresh">Refresh</button>
+      </div>
+    </div>
+  `;
+}
+
+/**
+ * Draws the Matter pairing QR code.
+ */
+function renderMatterQr(payload) {
+  const container = document.getElementById("matter-qr");
+  if (!container) return;
+
+  try {
+    if (typeof qrcode === "undefined") {
+      throw new Error("QR library not loaded");
+    }
+    const qr = qrcode(0, "M");
+    qr.addData(payload);
+    qr.make();
+
+    const img = document.createElement("img");
+    img.src = qr.createDataURL(6, 0);
+    img.alt = "Matter pairing QR code";
+    container.innerHTML = "";
+    container.appendChild(img);
+  } catch (error) {
+    console.error("[App] Failed to render Matter QR:", error);
+    container.innerHTML = `<div class="qr-code-error"><p class="text-muted">${escapeHtml(payload)}</p></div>`;
+  }
+}
+
+/**
+ * Wires up controls inside the Matter panel.
+ */
+function attachMatterListeners() {
+  const pairing = matterState.status?.pairing;
+  if (pairing?.qrPairingCode) {
+    renderMatterQr(pairing.qrPairingCode);
+  }
+
+  document.getElementById("matter-toggle")?.addEventListener("change", handleMatterToggle);
+  document.getElementById("matter-refresh")?.addEventListener("click", loadMatterStatus);
+  document.getElementById("matter-reset")?.addEventListener("click", handleMatterReset);
+  document
+    .getElementById("matter-save-identity")
+    ?.addEventListener("click", handleMatterIdentitySave);
+  document.getElementById("matter-copy-code")?.addEventListener("click", () => {
+    const code = matterState.status?.pairing?.manualPairingCode;
+    if (!code) return;
+    navigator.clipboard
+      ?.writeText(code)
+      .then(() => showToast("Setup code copied", "success"))
+      .catch(() => showToast("Could not copy setup code", "error"));
+  });
+
+  for (const select of document.querySelectorAll(
+    "[data-matter-kind], [data-matter-kind-advanced]"
+  )) {
+    select.addEventListener("change", handleMatterKindChange);
+  }
+}
+
+function handleMatterKindChange(event) {
+  const select = event.target;
+  const deviceId =
+    select.getAttribute("data-matter-kind") || select.getAttribute("data-matter-kind-advanced");
+  if (!deviceId) return;
+
+  const value = select.value;
+  const kind = value === "__auto__" ? null : value;
+
+  runMatterAction(
+    () => api.setMatterDeviceKind(deviceId, kind),
+    "Updating device type...",
+    kind ? "Device type updated" : "Using automatic type"
+  );
+}
+
+/**
+ * Runs a Matter mutation with busy state and error reporting.
+ */
+async function runMatterAction(action, pendingMessage, successMessage) {
+  matterState.busy = true;
+  renderMatterPanel();
+  showToast(pendingMessage, "info");
+
+  try {
+    matterState.status = await action();
+    showToast(successMessage, "success");
+  } catch (error) {
+    showToast(error.message || "Matter request failed", "error");
+    try {
+      matterState.status = await api.getMatterStatus();
+    } catch {
+      // keep previous status
+    }
+  } finally {
+    matterState.busy = false;
+    renderMatterPanel();
+    refreshMatterBadge();
+  }
+}
+
+function handleMatterToggle(event) {
+  const enable = event.target.checked;
+  runMatterAction(
+    () => (enable ? api.enableMatter() : api.disableMatter()),
+    enable ? "Starting Matter bridge..." : "Stopping Matter bridge...",
+    enable ? "Matter bridge enabled" : "Matter bridge disabled"
+  );
+}
+
+function handleMatterReset() {
+  const confirmed = window.confirm(
+    "Clear the Matter pairing? Remove “Open Wemo” from Google Home first, then pair again."
+  );
+  if (!confirmed) return;
+
+  runMatterAction(() => api.resetMatterPairing(), "Resetting pairing...", "Pairing reset");
+}
+
+function handleMatterIdentitySave() {
+  const vendorId = document.getElementById("matter-vendor-id")?.value?.trim();
+  const productId = document.getElementById("matter-product-id")?.value?.trim();
+
+  if (!vendorId || !productId) {
+    showToast("Vendor ID and Product ID are required", "error");
+    return;
+  }
+
+  const confirmed = window.confirm(
+    "Changing the vendor/product ID clears the current pairing. Continue?"
+  );
+  if (!confirmed) return;
+
+  runMatterAction(
+    () => api.setMatterIdentity(vendorId, productId),
+    "Updating Matter identity...",
+    "Matter identity updated"
+  );
 }
 
 // ============================================


### PR DESCRIPTION
## Summary
- Add an in-process Matter aggregator bridge so WeMo switches/plugs can be controlled from Google Home, Apple Home, and Alexa on the local network
- Extract `DeviceService` so REST and Matter share discovery, control, and state events
- Add PWA Settings → **Google Home & Matter** (enable/disable, pairing QR/code, auto device-type mapping with optional override)
- Document setup and troubleshooting in `docs/GOOGLE-HOME.md` and component design in `docs/MATTER.md`

## Test plan
- [ ] `bun run lint` / `bun run typecheck` / `bun run test` pass
- [ ] Enable Matter in Settings → Google Home & Matter; status shows devices as Plug or Light
- [ ] Register VID/PID in Google Home Developer Console (`0xFFF1` / `0x8001`)
- [ ] Pair via QR; Nest Matter hub on same Wi-Fi
- [ ] Toggle from Google Home **home/room tile** (not the device settings page)
- [ ] Control from Open Wemo PWA still works and stays in sync
- [ ] Reset pairing and re-pair works after a failed attempt

## Notes for reviewers
- Google Home requires a Nest Matter hub and a one-time Developer Console integration for uncertified VID/PID (documented)
- Matter persistence uses SQLite under Bun on Windows to avoid file-driver `EPERM` issues